### PR TITLE
fix: run E2E tests against local server to fix all 11 failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,41 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Install dependencies
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: uv sync --frozen
+
+      - name: Install Node dependencies
         run: npm ci
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium msedge
 
+      - name: Start local server
+        run: |
+          uv run uvicorn workshop.server:app --host 0.0.0.0 --port 8080 &
+          echo "Waiting for server..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/api/health >/dev/null 2>&1; then
+              echo "✅ Server is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "❌ Server failed to start"
+          exit 1
+
       - name: Run structural E2E tests (mocked)
         run: npx playwright test --grep-invert Smoke --project="Desktop Edge"
+        env:
+          BASE_URL: http://localhost:8080
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -28,6 +28,8 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.review.outputs.preview_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -152,6 +154,37 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**URL:** ${{ steps.review.outputs.preview_url }}" >> "$GITHUB_STEP_SUMMARY"
           echo "**Commit:** \`${GITHUB_SHA:0:7}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  e2e:
+    name: E2E Tests (Preview)
+    needs: deploy
+    if: needs.deploy.outputs.preview_url != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium msedge
+
+      - name: Run structural E2E tests against preview
+        run: npx playwright test --grep-invert Smoke --project="Desktop Edge"
+        env:
+          BASE_URL: ${{ needs.deploy.outputs.preview_url }}
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-staging
+          path: playwright-report/
+          retention-days: 14
 
   deactivate:
     name: Deactivate Preview


### PR DESCRIPTION
## Problem

All 11 structural E2E test failures in CI have the same root cause: the \2e-structural\ job tests against the **hardcoded production URL** from \playwright.config.ts\, not the current PR code. The production deployment was out of date, so all selectors, API endpoints, and assertions failed.

**Verification:** Running the same 25 tests against a local server from the current code: **25/25 pass, 0 failures.**

## Changes

### \ci.yml\ — Local server for CI
- Added Python/uv setup to the \2e-structural\ job
- Starts FastAPI server locally on port 8080
- Waits for health check before running tests
- Sets \BASE_URL=http://localhost:8080\ for Playwright

### \deploy-stage.yml\ — E2E after staging deployment
- Added \outputs\ to the \deploy\ job to expose \preview_url\
- Added new \2e\ job that runs after \deploy\
- Tests run against the PR preview URL
- Uploads Playwright report as artifact

## Why this fixes all 11 failures

The tests were correct all along — they just weren't testing the right server:
- 7 workshop structural tests (selectors, Behind the Scenes, Document API) — all match current HTML
- 4 error resilience tests — all assertions match current frontend error handling