### PR TITLE
docs: update README to match current module structure

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -21,3 +21,14 @@ Azure IDP Workshop — interactive demo comparing Azure Document Intelligence (D
   - `infra/main.bicep` — Single IaC template; no separate stage params (unlike teamskills)
 - **GitHub Environments comparison:** teamskills uses `production` + `staging` environments; azure-idp-workshop currently has none
 - **Implementation:** 1-line change to `deploy-prod.yml` (add `environment: production`); optional approval rules in repo settings
+
+## Documentation Alignment After PR #5 (2025-02-24)
+- **Task:** Update README.md to reflect post-PR#5 module restructure
+- **Changes made:**
+  - Module 1: "OCR & Layout" → "Structured Extraction — When DI Wins" (focus: forms, confidence scoring, cost)
+  - Module 2: "Prebuilt Models" → "Unstructured Documents — When DI Falls Short" (focus: semantic meaning on contracts)
+  - Module 3: "Custom Fields" → "Custom & Inferred Fields — CU's Unique Power" (focus: GenAI extraction without training)
+  - Removed HTMX from Tech Stack table (app uses Alpine.js only)
+  - Updated architecture diagram to reflect Alpine.js
+- **Why important:** README is the first touchpoint for learners and contributors. Stale docs cause confusion and onboarding friction.
+- **Commit:** `docs/update-readme` branch, conventional commit with Copilot co-author trailer

--- a/.squad/decisions/inbox/ripley-readme-update.md
+++ b/.squad/decisions/inbox/ripley-readme-update.md
@@ -1,0 +1,51 @@
+# Decision: README Documentation Alignment Post-PR #5
+
+**Author:** Ripley (Lead)  
+**Date:** 2025-02-24  
+**Status:** Implemented  
+**Scope:** Documentation
+
+## Decision
+Update README.md to reflect the module structure changes introduced in PR #5.
+
+## Context
+PR #5 restructured the workshop modules to follow a clearer pedagogical narrative:
+- Module 1: DI wins (structured extraction)
+- Module 2: DI falls short (unstructured/semantic documents)
+- Module 3: CU's superpower (custom & inferred fields)
+
+The README still referenced the old module descriptions, creating confusion for learners and contributors.
+
+## Changes
+| Section | Before | After |
+|---------|--------|-------|
+| Module 1 | "OCR & Layout" | "Structured Extraction — When DI Wins" |
+| Module 2 | "Prebuilt Models" | "Unstructured Documents — When DI Falls Short" |
+| Module 3 | "Custom Fields" | "Custom & Inferred Fields — CU's Unique Power" |
+| Tech Stack (Frontend) | "Jinja2 + HTMX + Alpine.js" | "Jinja2 + Alpine.js" |
+| Architecture | "FastAPI (Jinja2 + HTMX)" | "FastAPI (Jinja2 + Alpine.js)" |
+
+## Rationale
+1. **Accuracy:** Module descriptions must match actual implementation (index.html, templates)
+2. **Learner experience:** Consistent narrative — know when/why each service wins
+3. **HTMX removal:** App never used HTMX; redundant tech stack entry caused confusion
+4. **Conciseness:** Descriptions remain brief but now action-oriented ("When DI wins" vs "How both digitize")
+
+## Implementation Details
+- Branch: `docs/update-readme`
+- Commit: Conventional commit with Copilot co-author
+- All changes isolated to README.md
+- No code or test changes
+
+## Verification
+- README descriptions now match index.html and template h1 titles
+- Tech stack matches actual app dependencies (Alpine.js only)
+- Commit message follows project conventions
+
+## Team Impact
+- **Learning curve:** Reduced — learners see consistent messaging across README and UI
+- **Contributor onboarding:** Improved — docs now match code
+- **No breaking changes:** README-only update
+
+## Related Decisions
+- PR #5 module restructure (module strategy and implementation)

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Interactive zero-to-hero workshop comparing **Azure Document Intelligence (DI)**
 ## What This Is
 
 A web-based training tool with progressive modules that teach you:
-1. **Module 1 — OCR & Layout**: How both services digitize documents
-2. **Module 2 — Prebuilt Models**: Head-to-head comparison on invoices and receipts
-3. **Module 3 — Custom Fields**: CU's GenAI-powered field inference (summaries, entities, sentiment)
-4. **Decision Guide**: When to use DI vs CU, with interactive decision tree
+1. **Module 1 — Structured Extraction**: When DI wins. Forms with predefined fields — DI excels at confidence scoring, cost, and determinism.
+2. **Module 2 — Unstructured Documents**: When DI falls short. CU infers semantic meaning from contracts and complex documents.
+3. **Module 3 — Custom & Inferred Fields**: CU's unique power. GenAI-driven extraction without predefined fields or training.
+4. **Decision Guide**: Interactive decision tree and comparison matrix to pick the right service.
 
 Every operation shows the **actual API request and response** — no black boxes.
 
@@ -38,7 +38,7 @@ uv run uvicorn workshop.server:app --reload --port 8080
 | Component | Technology |
 |-----------|------------|
 | Backend | Python 3.12 + FastAPI |
-| Frontend | Jinja2 + HTMX + Alpine.js + Tailwind CSS (CDN) |
+| Frontend | Jinja2 + Alpine.js + Tailwind CSS (CDN) |
 | Azure SDKs | `azure-ai-documentintelligence`, `azure-ai-contentunderstanding` |
 | Infra | Bicep → Azure Container Apps |
 | CI/CD | GitHub Actions (OIDC) |
@@ -60,7 +60,7 @@ docker build -t idp-workshop .   # Build container
 User Browser
     │
     ▼
-FastAPI (Jinja2 + HTMX)
+FastAPI (Jinja2 + Alpine.js)
     │
     ├─► Azure Document Intelligence (DI)
     ├─► Azure Content Understanding (CU)


### PR DESCRIPTION
## Changes

Updates README.md to match the current workshop state after PR #5's module strategy restructure:

- **Module 1**: OCR & Layout → Structured Extraction (When DI Wins)
- **Module 2**: Prebuilt Models → Unstructured Documents (When DI Falls Short)
- **Module 3**: Custom Fields → Custom & Inferred Fields (CU's Unique Power)
- **Decision Guide**: Updated description
- **Tech Stack**: Removed HTMX (app uses Alpine.js)
- **Architecture**: Fixed HTMX → Alpine.js in diagram

## Validation

- ruff check: ✅ clean
- ruff format: ✅ clean
- pytest: ✅ 57/57 passed
