### PR TITLE
ci: ensure resource group exists before Bicep deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -17,6 +17,7 @@ permissions:
 
 env:
   AZURE_RESOURCE_GROUP: rg-idp-workshop
+  LOCATION: eastus
   ACR_NAME: idpworkshopacr
   IMAGE_NAME: idp-workshop
   ENVIRONMENT: prod
@@ -42,6 +43,9 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Ensure resource group
+        run: az group create --name ${{ env.AZURE_RESOURCE_GROUP }} --location ${{ env.LOCATION }} --output none
 
       - name: Ensure infrastructure
         id: infra

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -1,9 +1,7 @@
 name: PR Staging
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -16,6 +14,7 @@ concurrency:
 
 env:
   AZURE_RESOURCE_GROUP: rg-idp-workshop
+  LOCATION: eastus
   ACR_NAME: idpworkshopacr
   IMAGE_NAME: idp-workshop
   CONTAINERAPP_NAME: idp-workshop
@@ -44,6 +43,9 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Ensure resource group
+        run: az group create --name ${{ env.AZURE_RESOURCE_GROUP }} --location ${{ env.LOCATION }} --output none
 
       - name: Ensure infrastructure
         id: infra


### PR DESCRIPTION
## What

1. Adds `az group create` before Bicep deploy in both workflows — makes pipeline self-healing
2. Disables PR staging workflow (changed trigger from `pull_request` to `workflow_dispatch` only)

## Why

- **Self-healing RG:** The Bicep deploy uses `scope: resourceGroup` which requires the RG to exist. If MCAPS cost control deletes it, the pipeline now recreates it automatically.
- **Staging disabled:** PR preview deployments are too expensive for a demo repo. The workflow is preserved but only runs on manual dispatch.

## Changes

- `deploy-prod.yml`: Added `LOCATION` env var, added "Ensure resource group" step
- `deploy-stage.yml`: Same, plus changed trigger from `pull_request` to `workflow_dispatch`

`az group create` is idempotent — no-ops if the RG already exists.
