### PR TITLE
ci: handle fresh container app creation on first deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -148,21 +148,57 @@ jobs:
       - name: Deploy app revision
         id: deploy
         run: |
-          az containerapp update \
-            --name idp-workshop \
+          IDENTITY_RESOURCE_ID=$(az identity show \
+            --name ${{ env.IDENTITY_NAME }} \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --image ${{ steps.image.outputs.image-ref }} \
-            --set-env-vars \
-              ENVIRONMENT=${{ env.ENVIRONMENT }} \
-              AI_SERVICES_ENDPOINT=${{ steps.runtime.outputs.ai_services_endpoint }} \
-              STORAGE_ACCOUNT_URL=${{ steps.runtime.outputs.storage_account_url }} \
-              LOG_LEVEL=INFO \
-              AZURE_CLIENT_ID=${{ steps.runtime.outputs.azure_client_id }} \
-              CU_COMPLETION_DEPLOYMENT=gpt-4.1 \
-              CU_EMBEDDING_DEPLOYMENT=text-embedding-3-large \
-              AIS_ENDPOINT=${{ steps.runtime.outputs.ais_endpoint }} \
-              AIS_INDEX_NAME=workshop-documents \
-            --output none
+            --query id -o tsv)
+          CAE_ID=$(az containerapp env show \
+            --name idp-cae \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query id -o tsv)
+
+          if az containerapp show --name idp-workshop --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --query name -o tsv 2>/dev/null; then
+            echo "Container app exists — updating"
+            az containerapp update \
+              --name idp-workshop \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --image ${{ steps.image.outputs.image-ref }} \
+              --set-env-vars \
+                ENVIRONMENT=${{ env.ENVIRONMENT }} \
+                AI_SERVICES_ENDPOINT=${{ steps.runtime.outputs.ai_services_endpoint }} \
+                STORAGE_ACCOUNT_URL=${{ steps.runtime.outputs.storage_account_url }} \
+                LOG_LEVEL=INFO \
+                AZURE_CLIENT_ID=${{ steps.runtime.outputs.azure_client_id }} \
+                CU_COMPLETION_DEPLOYMENT=gpt-4.1 \
+                CU_EMBEDDING_DEPLOYMENT=text-embedding-3-large \
+                AIS_ENDPOINT=${{ steps.runtime.outputs.ais_endpoint }} \
+                AIS_INDEX_NAME=workshop-documents \
+              --output none
+          else
+            echo "Container app does not exist — creating"
+            az containerapp create \
+              --name idp-workshop \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --environment "$CAE_ID" \
+              --image ${{ steps.image.outputs.image-ref }} \
+              --registry-server ${{ env.ACR_NAME }}.azurecr.io \
+              --registry-identity "$IDENTITY_RESOURCE_ID" \
+              --user-assigned "$IDENTITY_RESOURCE_ID" \
+              --ingress external --target-port 8080 \
+              --revisions-mode multiple \
+              --min-replicas 1 --max-replicas 3 \
+              --env-vars \
+                ENVIRONMENT=${{ env.ENVIRONMENT }} \
+                AI_SERVICES_ENDPOINT=${{ steps.runtime.outputs.ai_services_endpoint }} \
+                STORAGE_ACCOUNT_URL=${{ steps.runtime.outputs.storage_account_url }} \
+                LOG_LEVEL=INFO \
+                AZURE_CLIENT_ID=${{ steps.runtime.outputs.azure_client_id }} \
+                CU_COMPLETION_DEPLOYMENT=gpt-4.1 \
+                CU_EMBEDDING_DEPLOYMENT=text-embedding-3-large \
+                AIS_ENDPOINT=${{ steps.runtime.outputs.ais_endpoint }} \
+                AIS_INDEX_NAME=workshop-documents \
+              --output none
+          fi
 
           APP_URL=$(az containerapp show \
             --name idp-workshop \


### PR DESCRIPTION
## What

Makes the deploy workflow handle fresh container app creation — currently fails with "containerapp does not exist" on first deploy after infrastructure deletion.

## Why

The Bicep template only creates the container app when a `containerImage` param is provided, but the workflow doesn't pass one (it uses `az containerapp update` separately). On a fresh deploy after the RG is recreated, the update fails because there's no app to update.

## Changes

- `deploy-prod.yml`: Deploy step now checks if the container app exists. If yes, runs `update` (existing behavior). If no, runs `create` with the correct environment, managed identity, ACR registry, and ingress config.

## Urgency

The production app has been down since the RG was deleted by MCAPS cost control. This fix, combined with the RG self-healing from PR #59, makes the pipeline fully resilient to total infrastructure loss.
