### PR TITLE
ci: Auto-approve and auto-merge Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot Auto-Merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-Merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-approve minor and patch updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (squash)
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Automate Dependabot PR handling so minor/patch dependency updates merge without manual intervention.

## Changes

- **New workflow** `.github/workflows/dependabot-auto-merge.yml` — triggers on `pull_request_target` for `dependabot[bot]`
- Auto-approves and enables squash auto-merge for **minor and patch** updates
- **Major version bumps** are left for manual review
- Enabled GitHub auto-merge on the repository setting

## How It Works

1. Dependabot opens a PR
2. Workflow auto-approves + queues squash auto-merge
3. GitHub waits for CI checks (lint, test, docker build, E2E) to pass
4. PR is squash-merged automatically

No dependency update ships without passing the full CI pipeline.
