### PR TITLE
fix: Correct pricing, SDK status, and DI characterization in workshop pages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "MIT" }
 requires-python = ">=3.12,<3.13"
 dependencies = [
     # Azure AI Content Understanding
-    "azure-ai-contentunderstanding>=1.0.0b1",
+    "azure-ai-contentunderstanding==1.1.0",
     # Azure Document Intelligence
     "azure-ai-documentintelligence>=1.0.0",
     # Azure Storage & Identity

--- a/src/workshop/templates/guide.html
+++ b/src/workshop/templates/guide.html
@@ -47,13 +47,14 @@
             <tbody class="divide-y divide-gray-100">
                 <tr><td class="py-2 px-4 font-medium">OCR & Layout</td><td class="text-center">✅ Excellent</td><td class="text-center">✅ Excellent (improved)</td></tr>
                 <tr><td class="py-2 px-4 font-medium">Prebuilt Models</td><td class="text-center">✅ Invoice, Receipt, W-2, ID</td><td class="text-center">✅ Same + more</td></tr>
-                <tr><td class="py-2 px-4 font-medium">Custom Fields (GenAI)</td><td class="text-center">❌ Not supported</td><td class="text-center">✅ Inferred fields</td></tr>
+                <tr><td class="py-2 px-4 font-medium">Custom Fields (GenAI)</td><td class="text-center">⚠️ Custom models (trained)</td><td class="text-center">✅ Inferred fields (zero-shot)</td></tr>
                 <tr><td class="py-2 px-4 font-medium">Multimodal (Audio/Video)</td><td class="text-center">❌ Documents only</td><td class="text-center">✅ Docs + Audio + Video + Images</td></tr>
                 <tr><td class="py-2 px-4 font-medium">GenAI Required</td><td class="text-center">❌ No (deterministic)</td><td class="text-center">✅ Yes (Foundry models)</td></tr>
                 <tr><td class="py-2 px-4 font-medium">Latency</td><td class="text-center">⚡ Very fast</td><td class="text-center">🔄 Slightly slower (GenAI)</td></tr>
-                <tr><td class="py-2 px-4 font-medium">Cost (Layout)</td><td class="text-center">$$ Standard</td><td class="text-center">$ Lower</td></tr>
-                <tr><td class="py-2 px-4 font-medium">SDK Maturity</td><td class="text-center">✅ GA (stable)</td><td class="text-center">🔶 Beta (1.0.0b1)</td></tr>
-                <tr><td class="py-2 px-4 font-medium">Microsoft Recommendation</td><td class="text-center">Legacy / existing</td><td class="text-center font-bold text-purple-700">✅ Recommended for new projects</td></tr>
+                <tr><td class="py-2 px-4 font-medium">Cost (Layout)</td><td class="text-center">$ Simple per-page</td><td class="text-center">$ Per-page + contextualization tokens</td></tr>
+                <tr><td class="py-2 px-4 font-medium">Cost (Custom/Fields)</td><td class="text-center">$ Per-page</td><td class="text-center">$$ Per-page + AOAI model tokens</td></tr>
+                <tr><td class="py-2 px-4 font-medium">SDK Maturity</td><td class="text-center">✅ GA (stable)</td><td class="text-center">✅ GA (API 2025-11-01)</td></tr>
+                <tr><td class="py-2 px-4 font-medium">Microsoft Recommendation</td><td class="text-center">Proven / existing workloads</td><td class="text-center font-bold text-purple-700">✅ Recommended for new projects</td></tr>
             </tbody>
         </table>
     </div>

--- a/src/workshop/templates/module1.html
+++ b/src/workshop/templates/module1.html
@@ -127,7 +127,7 @@ DI_URL=$(curl -s -D - -X POST "$ENDPOINT/formrecognizer/documentModels/prebuilt-
 curl -s -H "Authorization: Bearer $TOKEN" "$DI_URL" | python -m json.tool
 
 # --- Content Understanding (Layout) ---
-CU_URL=$(curl -s -D - -X POST "$ENDPOINT/contentunderstanding/analyzers/prebuilt-layout:analyze?api-version=2025-05-01-preview" \
+CU_URL=$(curl -s -D - -X POST "$ENDPOINT/contentunderstanding/analyzers/prebuilt-layout:analyze?api-version=2025-11-01" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/pdf" \
   --data-binary @invoice.pdf | grep -i operation-location | tr -d '\r' | cut -d' ' -f2)

--- a/src/workshop/templates/module1.html
+++ b/src/workshop/templates/module1.html
@@ -6,8 +6,8 @@
     <h1 class="text-3xl font-bold mb-2">Module 1: Structured Extraction — When DI Wins</h1>
     <p class="text-gray-600 text-lg">
         DI excels at forms with predefined fields and predictable variations. Compare extraction quality,
-        confidence scoring, and cost - DI is faster, cheaper ($0.01/page vs $0.05/page CU custom),
-        and deterministic.
+        confidence scoring, and cost — DI is faster, deterministic, and has simple per-page pricing
+        vs CU's multi-meter model (content extraction + AOAI tokens).
     </p>
 </div>
 
@@ -61,7 +61,7 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
                     <div class="font-semibold text-blue-800 mb-1">🔵 Document Intelligence (DI)</div>
-                    <p class="text-sm text-gray-700">Microsoft's battle-tested OCR + layout engine. Deterministic results, fast, cheap ($0.01/page). Built for high-volume, structured document processing - invoices, receipts, onboarding packets, and other fixed forms.</p>
+                    <p class="text-sm text-gray-700">Microsoft's battle-tested OCR + layout engine. Deterministic results, fast, simple per-page pricing. Built for high-volume, structured document processing — invoices, receipts, onboarding packets, and other fixed forms.</p>
                 </div>
                 <div class="bg-purple-50 border border-purple-200 rounded-lg p-4">
                     <div class="font-semibold text-purple-800 mb-1">🟣 Content Understanding (CU)</div>
@@ -77,7 +77,7 @@
                 <li><strong>Invoice processing pipelines</strong> — DI's prebuilt-invoice extracts fields + line items automatically</li>
                 <li><strong>Receipt scanning</strong> — DI's prebuilt-receipt handles photos of receipts with high accuracy</li>
                 <li><strong>Form digitization</strong> — DI excels at forms with fixed fields, even when labels drift between versions (tax forms, onboarding packets, applications)</li>
-                <li><strong>High-volume OCR</strong> — DI processes thousands of pages/minute at $0.01/page with deterministic results</li>
+                <li><strong>High-volume OCR</strong> — DI processes thousands of pages/minute with simple per-page pricing and deterministic results</li>
             </ul>
         </div>
 
@@ -695,7 +695,7 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
         <ul class="text-sm text-yellow-800 space-y-1 list-disc list-inside">
             <li><strong>DI is built for structured, high-volume extraction.</strong> Prebuilt models extract receipt/invoice fields without any configuration.</li>
             <li>DI provides <strong>deterministic results</strong> — same input always yields the same output. No GenAI variability.</li>
-            <li>DI is <strong>faster and cheaper</strong> — $0.01/page vs $0.05/page for CU custom extraction.</li>
+            <li>DI is <strong>faster and has simpler pricing</strong> — flat per-page rate vs CU's multi-meter model (content extraction + AOAI tokens).</li>
             <li><strong>Confidence scoring</strong> — each extracted field has a confidence percentage. Green (≥90%) means high certainty. This enables automated processing rules.</li>
             <li><strong>Controlled layout drift is still a DI problem.</strong> For Purchase Order A/B and Vendor Intake A/B, DI layout plus a thin normalization layer is often enough.</li>
             <li>Compare the <strong>API traces</strong> — notice DI's speed advantage on structured documents.</li>
@@ -770,12 +770,12 @@ result = poller.result()</code></pre>
                 </div>
             </div>
             <div>
-                <h4 class="font-semibold text-indigo-800 mb-2">💰 Pricing (per page)</h4>
+                <h4 class="font-semibold text-indigo-800 mb-2">💰 Pricing (per page, approximate)</h4>
                 <div class="grid grid-cols-2 gap-4 text-sm">
-                    <div class="bg-white p-3 rounded border"><span class="text-blue-700 font-medium">DI Layout:</span> $0.01/page</div>
-                    <div class="bg-white p-3 rounded border"><span class="text-purple-700 font-medium">CU Layout:</span> $0.005/page</div>
+                    <div class="bg-white p-3 rounded border"><span class="text-blue-700 font-medium">DI Layout:</span> ~$0.01/page (flat per-page)</div>
+                    <div class="bg-white p-3 rounded border"><span class="text-purple-700 font-medium">CU Layout:</span> ~$0.005/page + contextualization tokens</div>
                 </div>
-                <p class="text-xs text-gray-500 mt-1">CU Layout is 50% cheaper for equivalent OCR + layout functionality.</p>
+                <p class="text-xs text-gray-500 mt-1">CU Layout has a lower base per-page rate, but also incurs contextualization token costs. See <a href="https://azure.microsoft.com/pricing/details/content-understanding/" target="_blank" rel="noopener noreferrer" class="underline">CU pricing</a> and <a href="https://azure.microsoft.com/pricing/details/ai-document-intelligence/" target="_blank" rel="noopener noreferrer" class="underline">DI pricing</a> for current rates.</p>
             </div>
             <div>
                 <h4 class="font-semibold text-indigo-800 mb-2">🛠️ Quick Setup</h4>

--- a/src/workshop/templates/module2.html
+++ b/src/workshop/templates/module2.html
@@ -7,7 +7,7 @@
     <p class="text-gray-600 text-lg">
         CU's custom field inference uses GenAI to extract summaries, entities, sentiment, and risk from any document —
         define your own fields and watch CU understand documents, not just read them.
-        We also run DI side-by-side so you can see the difference: DI extracts text but can't infer meaning.
+        We also run DI side-by-side so you can see the difference: DI can extract custom fields too, but requires labeled training data instead of zero-shot GenAI inference.
     </p>
 </div>
 
@@ -71,7 +71,7 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
                     <div class="font-semibold text-blue-800 mb-1">🔵 Document Intelligence (DI)</div>
-                    <p class="text-sm text-gray-700">DI's layout model extracts raw text and structure. On unstructured documents like contracts, it gives you a wall of text — no semantic understanding, no summaries, no risk assessment.</p>
+                    <p class="text-sm text-gray-700">DI's layout model extracts raw text and structure. DI also supports custom extraction models (trained on labeled samples), but in layout mode it gives you text and tables — no semantic understanding or summaries.</p>
                 </div>
                 <div class="bg-purple-50 border border-purple-200 rounded-lg p-4">
                     <div class="font-semibold text-purple-800 mb-1">🟣 Content Understanding (CU)</div>
@@ -653,11 +653,11 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
             </div>
             <div>
                 <div class="font-medium text-sky-800 mb-1">📋 Schema-Driven, No Training</div>
-                <p class="text-xs text-gray-600">You defined 5 fields. CU extracted all 5 using GenAI — no labeled training data needed. Traditional ML extraction requires thousands of labeled examples.</p>
+                <p class="text-xs text-gray-600">You defined 5 fields. CU extracted all 5 using GenAI — no labeled training data needed. DI custom models can also extract custom fields, but require 5+ labeled samples per document type.</p>
             </div>
             <div>
                 <div class="font-medium text-sky-800 mb-1">💰 Cost vs Value</div>
-                <p class="text-xs text-gray-600">CU costs 5× more ($0.05 vs $0.01/page) — but it delivers structured intelligence, not a wall of text. Check the API trace for token usage.</p>
+                <p class="text-xs text-gray-600">CU has higher per-document costs — content extraction plus AOAI model tokens billed separately. But it delivers structured intelligence, not raw text. Check the API trace for token usage.</p>
             </div>
         </div>
     </div>
@@ -667,10 +667,10 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
         <h3 class="font-semibold text-yellow-900 mb-2">💡 What to Notice — CU's Semantic Superpower</h3>
         <ul class="text-sm text-yellow-800 space-y-1 list-disc list-inside">
             <li><strong>DI is text/layout extraction. CU is document understanding.</strong> That's the fundamental difference.</li>
-            <li>DI gave you a wall of text. CU gave you <strong>structured, actionable intelligence</strong> — parties, obligations, sentiment, risk.</li>
+            <li>DI's layout mode gave you raw text. CU gave you <strong>structured, actionable intelligence</strong> — parties, obligations, sentiment, risk.</li>
             <li>The custom fields were defined by YOU — try adding your own! CU uses GenAI to infer them. No model training, no labeled datasets.</li>
             <li><strong>Description quality matters.</strong> Better field descriptions → more accurate extraction. Click to edit and experiment.</li>
-            <li>DI cannot do this at all — it has no concept of "summarize" or "assess risk." That's why CU exists.</li>
+            <li>DI's layout mode has no concept of "summarize" or "assess risk." DI custom models can extract specific fields, but require labeled training data — CU does it zero-shot with GenAI.</li>
             <li>CU's custom fields use your Foundry model deployment (GPT-4.1) — check the API trace for token usage and cost.</li>
         </ul>
     </div>
@@ -704,12 +704,12 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
                 </div>
             </div>
             <div>
-                <h4 class="font-semibold text-indigo-800 mb-2">💰 Pricing Comparison</h4>
+                <h4 class="font-semibold text-indigo-800 mb-2">💰 Pricing Comparison (approximate)</h4>
                 <div class="grid grid-cols-2 gap-4 text-sm">
-                    <div class="bg-white p-3 rounded border"><span class="text-blue-700 font-medium">DI Layout:</span> $0.01/page (text only)</div>
-                    <div class="bg-white p-3 rounded border"><span class="text-purple-700 font-medium">CU Custom:</span> $0.05/page (includes GenAI)</div>
+                    <div class="bg-white p-3 rounded border"><span class="text-blue-700 font-medium">DI Layout:</span> ~$0.01/page (flat per-page)</div>
+                    <div class="bg-white p-3 rounded border"><span class="text-purple-700 font-medium">CU Custom:</span> ~$0.05/page + AOAI model tokens (billed separately)</div>
                 </div>
-                <p class="text-xs text-gray-500 mt-1">CU Custom costs 5× more — but it delivers <em>understanding</em>, not just text. The right tool depends on what you need.</p>
+                <p class="text-xs text-gray-500 mt-1">CU Custom pricing has two components: content extraction per-page and AOAI model token usage. See <a href="https://azure.microsoft.com/pricing/details/content-understanding/" target="_blank" rel="noopener noreferrer" class="underline">CU pricing</a> for current rates.</p>
             </div>
             <div>
                 <h4 class="font-semibold text-indigo-800 mb-2">🐍 Python SDK Code</h4>

--- a/src/workshop/templates/module2.html
+++ b/src/workshop/templates/module2.html
@@ -143,7 +143,7 @@ TOKEN=$(az account get-access-token --resource https://cognitiveservices.azure.c
 ENDPOINT="https://&lt;your-resource&gt;.cognitiveservices.azure.com"
 
 # --- Step 1: Create a custom analyzer (one-time) ---
-curl -X PUT "$ENDPOINT/contentunderstanding/analyzers/contract-analyzer?api-version=2025-05-01-preview" \
+curl -X PUT "$ENDPOINT/contentunderstanding/analyzers/contract-analyzer?api-version=2025-11-01" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -162,7 +162,7 @@ curl -X PUT "$ENDPOINT/contentunderstanding/analyzers/contract-analyzer?api-vers
   }'
 
 # --- Step 2: Analyze a contract ---
-CU_URL=$(curl -s -D - -X POST "$ENDPOINT/contentunderstanding/analyzers/contract-analyzer:analyze?api-version=2025-05-01-preview" \
+CU_URL=$(curl -s -D - -X POST "$ENDPOINT/contentunderstanding/analyzers/contract-analyzer:analyze?api-version=2025-11-01" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/pdf" \
   --data-binary @contract.pdf | grep -i operation-location | tr -d '\r' | cut -d' ' -f2)

--- a/src/workshop/templates/module3.html
+++ b/src/workshop/templates/module3.html
@@ -753,7 +753,7 @@ resource "azurerm_monitor_diagnostic_setting" "search_diag" {
                             <thead><tr><th>Resource</th><th>Tier</th><th>Cost</th><th>Notes</th></tr></thead>
                             <tbody>
                                 <tr><td>AI Search</td><td>Basic</td><td>~$75/mo</td><td>Semantic search included; 1 replica, 1 partition</td></tr>
-                                <tr><td>CU extraction</td><td>S0</td><td>~$0.05/page</td><td>GPT-4.1 token usage on top</td></tr>
+                                <tr><td>CU extraction</td><td>S0</td><td>~$0.05/page</td><td>+ AOAI model token usage (billed separately)</td></tr>
                                 <tr><td>Search queries</td><td>-</td><td>Free</td><td>Included in Basic tier</td></tr>
                             </tbody>
                         </table>

--- a/uv.lock
+++ b/uv.lock
@@ -38,16 +38,16 @@ wheels = [
 
 [[package]]
 name = "azure-ai-contentunderstanding"
-version = "1.0.0b1"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "isodate" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/bb/1074c95348f12da0b0945598244e04ca9c9d4a77598fcf49ecebc2a567dc/azure_ai_contentunderstanding-1.0.0b1.tar.gz", hash = "sha256:1dfd22ad4cb5ac459d0b478363a14902e6ab479cfce2492af4f6fc012d1644f3", size = 197582, upload-time = "2026-01-20T22:40:24.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/5a/6dbcb8278c8d3779fc03992d8a9f87a9ce5280437d76e72f8121f9a90d46/azure_ai_contentunderstanding-1.1.0.tar.gz", hash = "sha256:00f39c7cf2ba50c8d4586315f4295a45fad0881daaff07d13d33aea2bafc7ec8", size = 230330, upload-time = "2026-04-20T23:29:08.315Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/67/516c641799451660512766b69f422b98d245869305bd9581c52ff0393109/azure_ai_contentunderstanding-1.0.0b1-py3-none-any.whl", hash = "sha256:6f3b8e496c8d1a691363b2706036f6c9adce7eca31878ffd116a744a41c209ed", size = 98280, upload-time = "2026-01-20T22:40:26.071Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d6/6f60ac39b73a0b8a2bc86cd6895e26eccc20d9b7bde86814fe6a36964dff/azure_ai_contentunderstanding-1.1.0-py3-none-any.whl", hash = "sha256:d1d6bdeffe02f5c8cc5309f0e120a1338f51af04638605f9617b7b501e2d1dd6", size = 101987, upload-time = "2026-04-20T23:29:09.933Z" },
 ]
 
 [[package]]
@@ -134,7 +134,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "azure-ai-contentunderstanding", specifier = ">=1.0.0b1" },
+    { name = "azure-ai-contentunderstanding", specifier = "==1.1.0" },
     { name = "azure-ai-documentintelligence", specifier = ">=1.0.0" },
     { name = "azure-identity", specifier = ">=1.25.1" },
     { name = "azure-search-documents", specifier = ">=11.7.0b2" },


### PR DESCRIPTION
## Summary

Corrects factual inaccuracies in the Decision Guide and module pages that were identified by cross-referencing the latest Microsoft Learn documentation.

### Changes

- **`guide.html`** -- Decision Guide comparison matrix:
  - Custom Fields row: DI now correctly shows "Custom models (trained)" instead of "Not supported"
  - Cost rows: split into Layout and Custom/Fields rows; DI shown as simple per-page, CU shown as multi-meter (per-page + AOAI tokens)
  - SDK Maturity: CU updated from "Beta (1.0.0b1)" to "GA (API 2025-11-01)" -- CU SDK went GA in March 2026
  - Microsoft Recommendation: DI softened from "Legacy / existing" to "Proven / existing workloads"

- **`module1.html`** -- Pricing claims:
  - Removed hardcoded `$0.01/page vs $0.05/page` comparison
  - Pricing section now notes CU Layout has a lower base rate but also incurs contextualization token costs
  - Added links to official DI and CU pricing pages
  - Labels prices as approximate

- **`module2.html`** -- DI characterization and pricing:
  - DI description now acknowledges custom extraction models (require labeled training data)
  - "Traditional ML requires thousands of labeled examples" corrected to "5+ labeled samples"
  - CU Custom pricing now clearly states AOAI tokens are billed separately (not included in the per-page rate)
  - Teaching points softened: "DI cannot do this at all" -> "DI layout mode cannot; DI custom models can with training data"

- **`module3.html`** -- Minor wording fix to CU extraction pricing note for consistency

### Testing

- `uv run ruff check .` -- all checks passed
- `uv run ruff format --check .` -- 32 files already formatted
- `uv run pyright` -- 0 errors, 0 warnings
- `uv run pytest -v` -- 88/88 tests passed
- `npx playwright test --grep-invert Smoke --project="Desktop Edge"` -- 29/29 structural E2E tests passed
- `npx playwright test --grep Smoke --project="Desktop Edge"` -- 10/10 smoke tests passed against deployed app
