### PR TITLE
feat: Restore document uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A web-based training tool with progressive modules that teach you:
 
 Every operation shows the **actual API request and response** — no black boxes.
 
+Bundled samples are provided for guided demos, and each module also supports uploading your own document. Uploads are limited to 10 MB per file. Analysis-only uploads are request-scoped and are not stored by the app; search and batch workflows index extracted content and metadata into Azure AI Search.
+
 ## Key Insight
 
 > Microsoft recommends **starting with Content Understanding** for most new document processing scenarios.
@@ -70,7 +72,7 @@ FastAPI (Jinja2 + Alpine.js)
     │
     ├─► Azure Document Intelligence (DI)
     ├─► Azure Content Understanding (CU)
-    └─► Azure Blob Storage (samples)
+    └─► Azure AI Search (indexed extracted content)
 ```
 
 For detailed technical architecture, deployment patterns, and design decisions, see [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
@@ -92,4 +94,3 @@ To maintain code quality and prevent accidental breaking changes, configure the 
 ## License
 
 MIT
-

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,7 +83,7 @@ src/workshop/
 ├── routers/
 │   ├── di.py          (/api/di/*)     # Document Intelligence endpoints
 │   ├── cu.py          (/api/cu/*)     # Content Understanding endpoints
-│   ├── documents.py   (/api/documents/)  # Sample documents
+│   ├── documents.py   (/api/documents/)  # Samples and ephemeral uploads
 │   └── health.py      (/api/health)   # Health check
 ├── services/
 │   ├── document_intelligence.py       # DI SDK wrapper
@@ -131,7 +131,9 @@ src/workshop/
 |--------|------|---------|
 | `GET` | `/api/documents/samples` | List sample files |
 | `GET` | `/api/documents/samples/{filename}/raw` | Serve raw file bytes |
-| `POST` | `/api/documents/upload` | Upload document (10MB max) |
+| `POST` | `/api/documents/upload` | Validate uploaded document metadata (10MB max) |
+
+Uploads are request-scoped and raw bytes are not persisted by the workshop app. Modules 1 and 2 send uploaded files directly to analysis APIs. Modules 3 and 4 also accept uploads, but their enriched text and metadata are written into Azure AI Search as part of the indexing workflow.
 
 #### Health & Status
 | Method | Path | Purpose |

--- a/src/workshop/routers/ais.py
+++ b/src/workshop/routers/ais.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from datetime import UTC, datetime
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
+from pydantic import BaseModel, ValidationError
 
-from workshop.routers.documents import read_sample
+from workshop.routers.documents import DocumentSource, get_document_source
 from workshop.services import ai_search as ais_service
 from workshop.services import content_understanding as cu_service
 from workshop.services.cu_fields import extract_field_value
@@ -45,6 +46,7 @@ class SearchRequest(BaseModel):
     query: str
     top: int = 5
     use_semantic: bool = True
+    upload_scope: str | None = None
 
 
 @router.post("/ensure-index")
@@ -54,38 +56,57 @@ async def ensure_index() -> dict[str, Any]:
 
 
 @router.post("/index")
-async def index_document(request: IndexRequest) -> dict[str, Any]:
+async def index_document(
+    request: Request,
+    file: Annotated[UploadFile | None, File()] = None,
+    sample: Annotated[str | None, Form()] = None,
+    fields: Annotated[str | None, Form()] = None,
+    upload_scope: Annotated[str | None, Form()] = None,
+) -> dict[str, Any]:
     """Analyze a document with CU, then push enriched data to AI Search."""
-    try:
-        file_bytes = read_sample(request.sample)
-    except FileNotFoundError as err:
-        raise HTTPException(status_code=404, detail=f"Sample not found: {request.sample}") from err
-    filename = request.sample
+    content_type = request.headers.get("content-type", "")
+    if content_type.startswith("application/json"):
+        body = await _read_index_json(request)
+        document = await get_document_source(sample=body.sample)
+        return await _index_document_source(document, body.fields)
 
+    document = await get_document_source(file=file, sample=sample)
+    if document.source_type == "upload" and not upload_scope:
+        raise HTTPException(
+            status_code=400, detail="Provide 'upload_scope' when indexing an uploaded document"
+        )
+    return await _index_document_source(document, _parse_index_fields(fields), upload_scope)
+
+
+async def _index_document_source(
+    document: DocumentSource, fields: list[IndexField], upload_scope: str | None = None
+) -> dict[str, Any]:
     # Run CU custom extraction to get enriched fields
     # Build a stable, schema-sensitive analyzer ID from name, type, and description.
-    field_signatures = sorted(f"{f.name}:{f.type}:{f.description}" for f in request.fields)
+    field_signatures = sorted(f"{f.name}:{f.type}:{f.description}" for f in fields)
     analyzer_id = (
         "workshop_search_" + hashlib.md5("|".join(field_signatures).encode()).hexdigest()[:12]
     )
     cu_result = await cu_service.analyze_custom(
         analyzer_id,
-        file_bytes,
-        filename,
-        [{"name": f.name, "type": f.type, "description": f.description} for f in request.fields],
+        document.content,
+        document.filename,
+        [{"name": f.name, "type": f.type, "description": f.description} for f in fields],
     )
 
     # Build search document from CU results
-    doc_id = ais_service.build_document_id(filename)
+    doc_id = ais_service.build_document_id(_search_id_source(document, upload_scope))
     fields_dict = cu_result.get("result", {}).get("fields", {})
 
     search_doc = {
         "id": doc_id,
-        "title": filename,
+        "title": document.filename,
         "content": cu_result.get("result", {}).get("content", ""),
         "summary": _extract_field(fields_dict, "summary"),
         "key_topics": _extract_field(fields_dict, "key_topics"),
-        "source_doc": filename,
+        "source_doc": document.filename,
+        "source_type": document.source_type,
+        "upload_scope": upload_scope if document.source_type == "upload" else "",
         "indexed_at": datetime.now(tz=UTC).isoformat(),
     }
 
@@ -95,13 +116,13 @@ async def index_document(request: IndexRequest) -> dict[str, Any]:
     return {
         "result": {
             "cu_extraction": {
-                "fields": {
-                    k: _extract_field(fields_dict, k) for k in [f.name for f in request.fields]
-                },
+                "fields": {k: _extract_field(fields_dict, k) for k in [f.name for f in fields]},
                 "content_preview": (cu_result.get("result", {}).get("content") or "")[:500],
             },
             "indexing": index_result.get("result", {}),
             "document_id": doc_id,
+            "source_doc": document.filename,
+            "source_type": document.source_type,
         },
         "trace": {
             "cu": cu_result.get("trace", {}),
@@ -110,12 +131,42 @@ async def index_document(request: IndexRequest) -> dict[str, Any]:
     }
 
 
+async def _read_index_json(request: Request) -> IndexRequest:
+    try:
+        payload = await request.json()
+        return IndexRequest.model_validate(payload)
+    except json.JSONDecodeError as err:
+        raise HTTPException(status_code=400, detail="Request body must be valid JSON") from err
+    except ValidationError as err:
+        raise HTTPException(status_code=422, detail=err.errors()) from err
+
+
+def _parse_index_fields(fields: str | None) -> list[IndexField]:
+    if not fields:
+        return IndexRequest(sample="upload").fields
+    try:
+        payload = json.loads(fields)
+        return [IndexField.model_validate(field) for field in payload]
+    except json.JSONDecodeError as err:
+        raise HTTPException(status_code=400, detail="Field definitions must be valid JSON") from err
+    except (TypeError, ValidationError) as err:
+        raise HTTPException(status_code=422, detail="Field definitions are invalid") from err
+
+
+def _search_id_source(document: DocumentSource, upload_scope: str | None) -> str:
+    if document.source_type != "upload":
+        return document.id_source
+    return f"{document.id_source}:scope:{upload_scope}"
+
+
 @router.post("/query")
 async def search(request: SearchRequest) -> dict[str, Any]:
     """Search the document index."""
     if not request.query.strip():
         raise HTTPException(status_code=400, detail="Query cannot be empty")
-    return await ais_service.search_documents(request.query, request.top, request.use_semantic)
+    return await ais_service.search_documents(
+        request.query, request.top, request.use_semantic, request.upload_scope
+    )
 
 
 @router.get("/stats")

--- a/src/workshop/routers/batch.py
+++ b/src/workshop/routers/batch.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any
+import json
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
+from pydantic import BaseModel, ValidationError
 
+from workshop.routers.documents import DocumentSource, get_document_source
 from workshop.services import batch as batch_service
 
 router = APIRouter(prefix="/api/batch", tags=["batch"])
@@ -26,14 +28,73 @@ class BatchRequest(BaseModel):
 
 
 @router.post("/process")
-async def batch_process(request: BatchRequest) -> dict[str, Any]:
+async def batch_process(
+    request: Request,
+    files: Annotated[list[UploadFile] | None, File()] = None,
+    samples: Annotated[str | None, Form()] = None,
+    upload_scope: Annotated[str | None, Form()] = None,
+) -> dict[str, Any]:
     """Process multiple documents: CU enrichment + Search indexing."""
-    samples = request.deduplicated
+    content_type = request.headers.get("content-type", "")
+    if content_type.startswith("application/json"):
+        body = await _read_batch_json(request)
+        sample_names = body.deduplicated
+        _validate_batch_count(len(sample_names), empty_detail="No samples provided")
+        return await batch_service.process_batch(sample_names)
+
+    sample_names = list(dict.fromkeys(_parse_form_samples(samples)))
+    upload_files = files or []
+    _validate_batch_count(
+        len(sample_names) + len(upload_files), empty_detail="No documents provided"
+    )
+    if upload_files and not upload_scope:
+        raise HTTPException(
+            status_code=400, detail="Provide 'upload_scope' when indexing uploaded documents"
+        )
+    upload_sources = [await get_document_source(file=file) for file in upload_files]
+    items = _deduplicate_items([*sample_names, *upload_sources])
+    return await batch_service.process_batch_items(items, upload_scope)
+
+
+async def _read_batch_json(request: Request) -> BatchRequest:
+    try:
+        payload = await request.json()
+        return BatchRequest.model_validate(payload)
+    except json.JSONDecodeError as err:
+        raise HTTPException(status_code=400, detail="Request body must be valid JSON") from err
+    except ValidationError as err:
+        raise HTTPException(status_code=422, detail=err.errors()) from err
+
+
+def _parse_form_samples(samples: str | None) -> list[str]:
     if not samples:
-        raise HTTPException(status_code=400, detail="No samples provided")
-    if len(samples) > MAX_BATCH_SIZE:
+        return []
+    try:
+        payload = json.loads(samples)
+    except json.JSONDecodeError as err:
+        raise HTTPException(status_code=400, detail="Samples must be a JSON array") from err
+    if not isinstance(payload, list) or not all(isinstance(sample, str) for sample in payload):
+        raise HTTPException(status_code=422, detail="Samples must be a JSON array of strings")
+    return payload
+
+
+def _deduplicate_items(items: list[str | DocumentSource]) -> list[str | DocumentSource]:
+    seen: set[str] = set()
+    deduplicated: list[str | DocumentSource] = []
+    for item in items:
+        key = item if isinstance(item, str) else item.id_source
+        if key in seen:
+            continue
+        seen.add(key)
+        deduplicated.append(item)
+    return deduplicated
+
+
+def _validate_batch_count(count: int, empty_detail: str) -> None:
+    if not count:
+        raise HTTPException(status_code=400, detail=empty_detail)
+    if count > MAX_BATCH_SIZE:
         raise HTTPException(
             status_code=400,
-            detail=f"Batch size {len(samples)} exceeds maximum of {MAX_BATCH_SIZE}",
+            detail=f"Batch size {count} exceeds maximum of {MAX_BATCH_SIZE}",
         )
-    return await batch_service.process_batch(samples)

--- a/src/workshop/routers/cu.py
+++ b/src/workshop/routers/cu.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any
+import json
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, UploadFile
-from pydantic import BaseModel
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
+from pydantic import BaseModel, ValidationError
 
-from workshop.routers.documents import get_file_bytes, read_sample
+from workshop.routers.documents import get_document_source, get_file_bytes
 from workshop.services import content_understanding as cu_service
 
 router = APIRouter(prefix="/api/cu", tags=["content-understanding"])
@@ -48,17 +49,54 @@ async def cu_prebuilt(
 
 
 @router.post("/custom")
-async def cu_custom(request: CustomAnalyzeRequest) -> dict[str, Any]:
+async def cu_custom(
+    request: Request,
+    file: Annotated[UploadFile | None, File()] = None,
+    sample: Annotated[str | None, Form()] = None,
+    fields: Annotated[str | None, Form()] = None,
+    analyzer_id: Annotated[str | None, Form()] = None,
+) -> dict[str, Any]:
     """Run a CU custom analyzer with user-defined fields."""
-    if not request.sample:
-        raise HTTPException(status_code=400, detail="Provide 'sample' name in request body")
+    content_type = request.headers.get("content-type", "")
+    if content_type.startswith("application/json"):
+        body = await _read_custom_json(request)
+        document = await get_document_source(sample=body.sample)
+        field_values = [f.model_dump() for f in body.fields] if body.fields else None
+        return await cu_service.analyze_custom(
+            body.analyzer_id, document.content, document.filename, field_values
+        )
 
+    document = await get_document_source(file=file, sample=sample)
+    parsed_fields = _parse_custom_fields(fields)
+    return await cu_service.analyze_custom(
+        analyzer_id or "workshop-custom",
+        document.content,
+        document.filename,
+        parsed_fields,
+    )
+
+
+async def _read_custom_json(request: Request) -> CustomAnalyzeRequest:
     try:
-        file_bytes = read_sample(request.sample)
-    except FileNotFoundError:
-        raise HTTPException(
-            status_code=404, detail=f"Sample '{request.sample}' not found"
-        ) from None
+        payload = await request.json()
+        body = CustomAnalyzeRequest.model_validate(payload)
+    except json.JSONDecodeError as err:
+        raise HTTPException(status_code=400, detail="Request body must be valid JSON") from err
+    except ValidationError as err:
+        raise HTTPException(status_code=422, detail=err.errors()) from err
+    if not body.sample:
+        raise HTTPException(status_code=400, detail="Provide 'sample' name in request body")
+    return body
 
-    fields = [f.model_dump() for f in request.fields] if request.fields else None
-    return await cu_service.analyze_custom(request.analyzer_id, file_bytes, request.sample, fields)
+
+def _parse_custom_fields(fields: str | None) -> list[dict[str, Any]] | None:
+    if not fields:
+        return None
+    try:
+        payload = json.loads(fields)
+        parsed = [CustomField.model_validate(field).model_dump() for field in payload]
+    except json.JSONDecodeError as err:
+        raise HTTPException(status_code=400, detail="Field definitions must be valid JSON") from err
+    except (TypeError, ValidationError) as err:
+        raise HTTPException(status_code=422, detail="Field definitions are invalid") from err
+    return parsed

--- a/src/workshop/routers/di.py
+++ b/src/workshop/routers/di.py
@@ -6,42 +6,20 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, UploadFile
 
-from workshop.routers.documents import get_file_bytes
+from workshop.routers.documents import get_file_bytes, validate_document_extension
 from workshop.services import document_intelligence as di_service
 
 router = APIRouter(prefix="/api/di", tags=["document-intelligence"])
 
-# Formats supported by Azure DI Layout API
-DI_SUPPORTED_EXTENSIONS = {
-    ".pdf",
-    ".jpeg",
-    ".jpg",
-    ".png",
-    ".bmp",
-    ".tiff",
-    ".tif",
-    ".heif",
-    ".heic",
-    ".docx",
-    ".xlsx",
-    ".pptx",
-    ".html",
-}
-
 
 def _validate_format(filename: str) -> None:
     """Raise 400 if the file format is not supported by Document Intelligence."""
-    import os
-
-    ext = os.path.splitext(filename)[1].lower()
-    if ext and ext not in DI_SUPPORTED_EXTENSIONS:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Document Intelligence does not support '{ext}' files. "
-                f"Supported formats: PDF, JPEG, PNG, BMP, TIFF, HEIF, DOCX, XLSX, PPTX, HTML."
-            ),
-        )
+    try:
+        validate_document_extension(filename, service_name="Document Intelligence")
+    except HTTPException as err:
+        if filename.rsplit(".", 1)[-1] == filename:
+            return
+        raise err
 
 
 @router.post("/layout")

--- a/src/workshop/routers/documents.py
+++ b/src/workshop/routers/documents.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import mimetypes
+import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +19,37 @@ SAMPLES_DIR = Path(__file__).resolve().parents[3] / "samples"
 
 # 10 MB upload limit — container has only 1Gi memory
 MAX_UPLOAD_SIZE = 10 * 1024 * 1024
+UPLOAD_READ_CHUNK_SIZE = 1024 * 1024
+
+SUPPORTED_DOCUMENT_EXTENSIONS = {
+    ".pdf",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".bmp",
+    ".tiff",
+    ".tif",
+    ".heif",
+    ".heic",
+    ".docx",
+    ".xlsx",
+    ".pptx",
+    ".html",
+}
+
+SUPPORTED_DOCUMENT_FORMATS_LABEL = "PDF, JPEG, PNG, BMP, TIFF, HEIF, DOCX, XLSX, PPTX, HTML"
+
+
+@dataclass(frozen=True)
+class DocumentSource:
+    """A request-scoped document, from either a bundled sample or an upload."""
+
+    content: bytes
+    filename: str
+    id_source: str
+    source_type: str
+    content_type: str | None = None
+    content_hash: str | None = None
 
 
 def _resolve_sample_path(filename: str) -> Path:
@@ -27,6 +61,66 @@ def _resolve_sample_path(filename: str) -> Path:
     if not path.is_relative_to(SAMPLES_DIR.resolve()):
         raise HTTPException(status_code=400, detail="Invalid filename")
     return path
+
+
+def normalize_filename(filename: str | None) -> str:
+    """Return a safe display filename without path components or control chars."""
+    name = (filename or "").replace("\\", "/").rsplit("/", 1)[-1].strip()
+    name = re.sub(r"[\x00-\x1f\x7f]", "", name)
+    return name or "upload"
+
+
+def validate_document_extension(filename: str, service_name: str = "Uploaded documents") -> None:
+    """Raise 400 if a filename has an unsupported extension."""
+    ext = Path(filename).suffix.lower()
+    if ext and ext in SUPPORTED_DOCUMENT_EXTENSIONS:
+        return
+    if not ext:
+        detail = (
+            f"{service_name} requires a supported file extension. "
+            f"Supported formats: {SUPPORTED_DOCUMENT_FORMATS_LABEL}."
+        )
+    else:
+        detail = (
+            f"{service_name} does not support '{ext}' files. "
+            f"Supported formats: {SUPPORTED_DOCUMENT_FORMATS_LABEL}."
+        )
+    raise HTTPException(status_code=400, detail=detail)
+
+
+def _enforce_upload_size(content: bytes) -> None:
+    if len(content) > MAX_UPLOAD_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File exceeds maximum upload size of {MAX_UPLOAD_SIZE // (1024 * 1024)}MB",
+        )
+    if not content:
+        raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+
+async def read_upload(file: UploadFile) -> tuple[bytes, str]:
+    """Read and validate an uploaded document without storing it."""
+    filename = normalize_filename(file.filename)
+    validate_document_extension(filename)
+    chunks: list[bytes] = []
+    total_size = 0
+    while chunk := await file.read(UPLOAD_READ_CHUNK_SIZE):
+        total_size += len(chunk)
+        if total_size > MAX_UPLOAD_SIZE:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File exceeds maximum upload size of {MAX_UPLOAD_SIZE // (1024 * 1024)}MB",
+            )
+        chunks.append(chunk)
+    content = b"".join(chunks)
+    _enforce_upload_size(content)
+    return content, filename
+
+
+def build_upload_id_source(filename: str, content: bytes) -> tuple[str, str]:
+    """Build a deterministic identity from uploaded filename and content."""
+    digest = hashlib.sha256(content).hexdigest()
+    return f"upload:{filename}:{digest[:16]}", digest
 
 
 @router.get("/samples")
@@ -67,17 +161,13 @@ def get_sample(filename: str) -> dict[str, str]:
 
 @router.post("/upload")
 async def upload_document(file: UploadFile) -> dict[str, Any]:
-    """Accept an uploaded document and return its bytes (ephemeral, not stored)."""
-    content = await file.read()
-    if len(content) > MAX_UPLOAD_SIZE:
-        raise HTTPException(
-            status_code=413,
-            detail=f"File exceeds maximum upload size of {MAX_UPLOAD_SIZE // (1024 * 1024)}MB",
-        )
+    """Validate an uploaded document and return metadata without storing bytes."""
+    content, filename = await read_upload(file)
     return {
-        "filename": file.filename or "unknown",
+        "filename": filename,
         "size_bytes": len(content),
         "content_type": file.content_type,
+        "source_type": "upload",
     }
 
 
@@ -89,19 +179,41 @@ def read_sample(filename: str) -> bytes:
     return path.read_bytes()
 
 
+def get_sample_document_source(sample: str) -> DocumentSource:
+    """Read a bundled sample into a request-scoped document source."""
+    return DocumentSource(
+        content=read_sample(sample),
+        filename=sample,
+        id_source=sample,
+        source_type="sample",
+        content_type=mimetypes.guess_type(sample)[0],
+    )
+
+
 async def get_file_bytes(file: UploadFile | None, sample: str | None) -> tuple[bytes, str]:
     """Extract file bytes from upload or sample name, with size limit enforcement."""
+    source = await get_document_source(file=file, sample=sample)
+    return source.content, source.filename
+
+
+async def get_document_source(
+    file: UploadFile | None = None, sample: str | None = None
+) -> DocumentSource:
+    """Extract a request-scoped document source from an upload or sample name."""
     if file:
-        content = await file.read()
-        if len(content) > MAX_UPLOAD_SIZE:
-            raise HTTPException(
-                status_code=413,
-                detail=f"File exceeds maximum upload size of {MAX_UPLOAD_SIZE // (1024 * 1024)}MB",
-            )
-        return content, file.filename or "upload"
+        content, filename = await read_upload(file)
+        id_source, digest = build_upload_id_source(filename, content)
+        return DocumentSource(
+            content=content,
+            filename=filename,
+            id_source=id_source,
+            source_type="upload",
+            content_type=file.content_type,
+            content_hash=digest,
+        )
     if sample:
         try:
-            return read_sample(sample), sample
+            return get_sample_document_source(sample)
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail=f"Sample '{sample}' not found") from None
     raise HTTPException(status_code=400, detail="Provide 'file' upload or 'sample' name")

--- a/src/workshop/services/ai_search.py
+++ b/src/workshop/services/ai_search.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+from pathlib import Path
 from typing import Any
 
 from azure.core.exceptions import HttpResponseError
@@ -13,6 +14,7 @@ from workshop.config import settings
 from workshop.services.api_trace import ApiTrace, TraceTimer, sanitize_headers
 
 logger = logging.getLogger(__name__)
+SAMPLES_DIR = Path(__file__).resolve().parents[3] / "samples"
 
 
 def build_document_id(source_doc: str) -> str:
@@ -83,6 +85,8 @@ async def ensure_index() -> dict[str, Any]:
                 SearchableField(name="summary", type=SearchFieldDataType.String),
                 SearchableField(name="key_topics", type=SearchFieldDataType.String),
                 SimpleField(name="source_doc", type=SearchFieldDataType.String, filterable=True),
+                SimpleField(name="source_type", type=SearchFieldDataType.String, filterable=True),
+                SimpleField(name="upload_scope", type=SearchFieldDataType.String, filterable=True),
                 SimpleField(
                     name="indexed_at",
                     type=SearchFieldDataType.DateTimeOffset,
@@ -113,6 +117,13 @@ async def ensure_index() -> dict[str, Any]:
             result = await asyncio.to_thread(client.create_or_update_index, index)
             trace.response_status = 200
             result_dict = {"name": result.name, "fields": len(result.fields)}
+            try:
+                result_dict["sample_metadata_backfill"] = await asyncio.to_thread(
+                    _backfill_sample_source_metadata
+                )
+            except Exception as e:
+                logger.warning("Sample metadata backfill failed: %s", e)
+                result_dict["sample_metadata_backfill"] = {"error": f"{type(e).__name__}: {e}"}
             trace.response_body = result_dict
         except HttpResponseError as e:
             trace.error = f"HttpResponseError: {e}"
@@ -177,7 +188,9 @@ async def index_document(doc: dict[str, Any]) -> dict[str, Any]:
     return {"result": result_dict, "trace": trace.to_dict()}
 
 
-async def search_documents(query: str, top: int = 5, use_semantic: bool = True) -> dict[str, Any]:
+async def search_documents(
+    query: str, top: int = 5, use_semantic: bool = True, upload_scope: str | None = None
+) -> dict[str, Any]:
     """Search the index. Returns results + trace."""
     trace = ApiTrace(service="AI-Search", operation="search")
     trace.request_url = f"{settings.ais_endpoint}/indexes/{settings.ais_index_name}/docs/search"
@@ -187,6 +200,7 @@ async def search_documents(query: str, top: int = 5, use_semantic: bool = True) 
         "search": query,
         "top": top,
         "queryType": "semantic" if use_semantic else "simple",
+        "filter": _build_visibility_filter(upload_scope),
     }
 
     with TraceTimer() as timer:
@@ -197,6 +211,7 @@ async def search_documents(query: str, top: int = 5, use_semantic: bool = True) 
                 "search_text": query,
                 "top": top,
                 "include_total_count": True,
+                "filter": _build_visibility_filter(upload_scope),
             }
             if use_semantic:
                 search_kwargs["query_type"] = "semantic"
@@ -206,27 +221,30 @@ async def search_documents(query: str, top: int = 5, use_semantic: bool = True) 
                 return client.search(**search_kwargs)
 
             results = await asyncio.to_thread(_run_search)
-
-            hits = []
-            for r in results:
-                hits.append(
-                    {
-                        "id": r.get("id"),
-                        "title": r.get("title", ""),
-                        "summary": r.get("summary", ""),
-                        "key_topics": r.get("key_topics", ""),
-                        "source_doc": r.get("source_doc", ""),
-                        "score": r.get("@search.score"),
-                        "reranker_score": r.get("@search.reranker_score"),
-                        "content_preview": (r.get("content") or "")[:300],
-                    }
-                )
-            count = results.get_count()
-            total = count if count is not None else len(hits)
+            result_dict = _search_results_to_dict(results, query)
             trace.response_status = 200
-            result_dict = {"hits": hits, "total": total, "query": query}
             trace.response_body = result_dict
         except HttpResponseError as e:
+            if _is_missing_filter_field_error(e):
+                ensure_result = await ensure_index()
+                if not ensure_result.get("trace", {}).get("error"):
+                    try:
+                        results = await asyncio.to_thread(_run_search)
+                        result_dict = _search_results_to_dict(results, query)
+                        trace.request_body["retried_after_ensure_index"] = True
+                        trace.response_status = 200
+                        trace.response_body = result_dict
+                        trace.error = ""
+                    except HttpResponseError as retry_error:
+                        trace.error = f"HttpResponseError: {retry_error}"
+                        trace.response_status = retry_error.status_code or 500
+                        result_dict = {"hits": [], "total": 0, "query": query}
+                    except Exception as retry_error:
+                        trace.error = f"{type(retry_error).__name__}: {retry_error}"
+                        trace.response_status = 500
+                        result_dict = {"hits": [], "total": 0, "query": query}
+                    trace.duration_ms = timer.duration_ms
+                    return {"result": result_dict, "trace": trace.to_dict()}
             trace.error = f"HttpResponseError: {e}"
             trace.response_status = e.status_code or 500
             result_dict = {"hits": [], "total": 0, "query": query}
@@ -237,6 +255,69 @@ async def search_documents(query: str, top: int = 5, use_semantic: bool = True) 
 
     trace.duration_ms = timer.duration_ms
     return {"result": result_dict, "trace": trace.to_dict()}
+
+
+def _search_results_to_dict(results: Any, query: str) -> dict[str, Any]:
+    hits = []
+    for r in results:
+        hits.append(
+            {
+                "id": r.get("id"),
+                "title": r.get("title", ""),
+                "summary": r.get("summary", ""),
+                "key_topics": r.get("key_topics", ""),
+                "source_doc": r.get("source_doc", ""),
+                "score": r.get("@search.score"),
+                "reranker_score": r.get("@search.reranker_score"),
+                "content_preview": (r.get("content") or "")[:300],
+            }
+        )
+    count = results.get_count()
+    total = count if count is not None else len(hits)
+    return {"hits": hits, "total": total, "query": query}
+
+
+def _is_missing_filter_field_error(error: HttpResponseError) -> bool:
+    message = str(error).lower()
+    if "source_type" not in message and "upload_scope" not in message:
+        return False
+    return any(term in message for term in ["could not", "not found", "unknown", "invalid"])
+
+
+def _build_visibility_filter(upload_scope: str | None) -> str:
+    base_filter = "source_type eq 'sample'"
+    if not upload_scope:
+        return base_filter
+    safe_scope = upload_scope.replace("'", "''")
+    return f"{base_filter} or upload_scope eq '{safe_scope}'"
+
+
+def _backfill_sample_source_metadata() -> dict[str, int]:
+    sample_names = _list_sample_names()
+    if not sample_names:
+        return {"attempted": 0, "updated": 0, "failed": 0}
+
+    client = _get_search_client()
+    documents = [
+        {
+            "id": build_document_id(sample),
+            "source_doc": sample,
+            "source_type": "sample",
+            "upload_scope": "",
+        }
+        for sample in sample_names
+    ]
+    results = client.merge_documents(documents=documents)
+    updated = sum(1 for result in results if result.succeeded)
+    return {"attempted": len(documents), "updated": updated, "failed": len(documents) - updated}
+
+
+def _list_sample_names() -> list[str]:
+    if not SAMPLES_DIR.exists():
+        return []
+    return sorted(
+        f.name for f in SAMPLES_DIR.iterdir() if f.is_file() and not f.name.startswith(".")
+    )
 
 
 async def get_index_stats() -> dict[str, Any]:

--- a/src/workshop/services/batch.py
+++ b/src/workshop/services/batch.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Any
 
-from workshop.routers.documents import read_sample
+from workshop.routers.documents import DocumentSource, read_sample
 from workshop.services import ai_search as ais_service
 from workshop.services import content_understanding as cu_service
 from workshop.services.cu_fields import extract_field_value
@@ -18,7 +19,17 @@ BATCH_FIELDS = [
 ]
 
 
+BatchItem = str | DocumentSource
+
+
 async def process_batch(samples: list[str]) -> dict[str, Any]:
+    """Process bundled samples through CU enrichment and Search indexing."""
+    return await process_batch_items(samples)
+
+
+async def process_batch_items(
+    items: Sequence[BatchItem], upload_scope: str | None = None
+) -> dict[str, Any]:
     """Process multiple documents: CU enrichment → Search indexing.
 
     Returns per-document results with timing and traces.
@@ -45,8 +56,8 @@ async def process_batch(samples: list[str]) -> dict[str, Any]:
     succeeded = 0
     failed = 0
 
-    for sample in samples:
-        doc_result = await _process_single(sample, analyzer_id)
+    for item in items:
+        doc_result = await _process_single_item(item, analyzer_id, upload_scope)
         results.append(doc_result)
 
         if doc_result.get("error"):
@@ -60,7 +71,7 @@ async def process_batch(samples: list[str]) -> dict[str, Any]:
         "result": {
             "documents": results,
             "summary": {
-                "total": len(samples),
+                "total": len(items),
                 "succeeded": succeeded,
                 "failed": failed,
                 "total_cu_ms": round(total_cu_ms, 2),
@@ -76,17 +87,27 @@ async def process_batch(samples: list[str]) -> dict[str, Any]:
 
 async def _process_single(sample: str, analyzer_id: str) -> dict[str, Any]:
     """Process a single document: read → CU extract → index."""
+    return await _process_single_item(sample, analyzer_id)
+
+
+async def _process_single_item(
+    item: BatchItem, analyzer_id: str, upload_scope: str | None = None
+) -> dict[str, Any]:
+    """Process a sample name or uploaded document source."""
     try:
-        file_bytes = read_sample(sample)
+        document = _resolve_batch_item(item)
     except Exception as e:
-        return {"sample": sample, "error": f"Cannot read sample: {e}"}
+        return {"sample": _item_name(item), "error": f"Cannot read document: {e}"}
 
     # CU enrichment
     try:
-        cu_result = await cu_service.analyze_custom(analyzer_id, file_bytes, sample, BATCH_FIELDS)
+        cu_result = await cu_service.analyze_custom(
+            analyzer_id, document.content, document.filename, BATCH_FIELDS
+        )
     except Exception as e:
         return {
-            "sample": sample,
+            "sample": document.filename,
+            "source_type": document.source_type,
             "error": f"CU extraction failed: {e}",
             "cu_trace": None,
         }
@@ -98,22 +119,25 @@ async def _process_single(sample: str, analyzer_id: str) -> dict[str, Any]:
     cu_trace_status = cu_result.get("trace", {}).get("response", {}).get("status", 0)
     if cu_trace_status >= 400 or cu_result.get("trace", {}).get("error"):
         return {
-            "sample": sample,
+            "sample": document.filename,
+            "source_type": document.source_type,
             "error": cu_result.get("trace", {}).get("error", f"CU returned HTTP {cu_trace_status}"),
             "cu_duration_ms": round(cu_duration, 2),
             "cu_trace": cu_result.get("trace"),
         }
 
     # Build search document
-    doc_id = ais_service.build_document_id(sample)
+    doc_id = ais_service.build_document_id(_search_id_source(document, upload_scope))
 
     search_doc = {
         "id": doc_id,
-        "title": sample,
+        "title": document.filename,
         "content": cu_result.get("result", {}).get("content", ""),
         "summary": extract_field_value(cu_fields, "summary"),
         "key_topics": extract_field_value(cu_fields, "key_topics"),
-        "source_doc": sample,
+        "source_doc": document.filename,
+        "source_type": document.source_type,
+        "upload_scope": upload_scope if document.source_type == "upload" else "",
         "indexed_at": datetime.now(tz=UTC).isoformat(),
     }
 
@@ -122,7 +146,8 @@ async def _process_single(sample: str, analyzer_id: str) -> dict[str, Any]:
         index_result = await ais_service.index_document(search_doc)
     except Exception as e:
         return {
-            "sample": sample,
+            "sample": document.filename,
+            "source_type": document.source_type,
             "error": f"Search indexing failed: {e}",
             "cu_fields": {
                 f["name"]: extract_field_value(cu_fields, f["name"]) for f in BATCH_FIELDS
@@ -137,7 +162,8 @@ async def _process_single(sample: str, analyzer_id: str) -> dict[str, Any]:
     search_trace_status = index_result.get("trace", {}).get("response", {}).get("status", 0)
     if search_trace_status >= 400 or index_result.get("trace", {}).get("error"):
         return {
-            "sample": sample,
+            "sample": document.filename,
+            "source_type": document.source_type,
             "error": index_result.get("trace", {}).get(
                 "error", f"Search returned HTTP {search_trace_status}"
             ),
@@ -151,7 +177,8 @@ async def _process_single(sample: str, analyzer_id: str) -> dict[str, Any]:
         }
 
     return {
-        "sample": sample,
+        "sample": document.filename,
+        "source_type": document.source_type,
         "document_id": doc_id,
         "cu_fields": {f["name"]: extract_field_value(cu_fields, f["name"]) for f in BATCH_FIELDS},
         "cu_duration_ms": round(cu_duration, 2),
@@ -159,3 +186,26 @@ async def _process_single(sample: str, analyzer_id: str) -> dict[str, Any]:
         "cu_trace": cu_result.get("trace"),
         "search_trace": index_result.get("trace"),
     }
+
+
+def _resolve_batch_item(item: BatchItem) -> DocumentSource:
+    if isinstance(item, DocumentSource):
+        return item
+    return DocumentSource(
+        content=read_sample(item),
+        filename=item,
+        id_source=item,
+        source_type="sample",
+    )
+
+
+def _item_name(item: BatchItem) -> str:
+    if isinstance(item, DocumentSource):
+        return item.filename
+    return item
+
+
+def _search_id_source(document: DocumentSource, upload_scope: str | None) -> str:
+    if document.source_type != "upload":
+        return document.id_source
+    return f"{document.id_source}:scope:{upload_scope}"

--- a/src/workshop/templates/base.html
+++ b/src/workshop/templates/base.html
@@ -23,6 +23,7 @@
 
     <!-- Marked.js for rendering markdown from CU results -->
     <script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.3.1/dist/purify.min.js"></script>
 
     <style>
         [x-cloak] { display: none !important; }
@@ -38,6 +39,24 @@
         .rendered-md p { margin: 0.25rem 0; font-size: 0.8rem; }
         .rendered-md ul, .rendered-md ol { padding-left: 1.25rem; font-size: 0.8rem; }
     </style>
+    <script>
+        function escapeHtml(value) {
+            const el = document.createElement('div');
+            el.textContent = value || '';
+            return el.innerHTML;
+        }
+
+        function safeMarkdown(value, maxLength = 3000) {
+            const text = (value || '').substring(0, maxLength);
+            if (!text) return 'No content';
+            if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') {
+                return escapeHtml(text);
+            }
+            return DOMPurify.sanitize(marked.parse(text), {
+                FORBID_TAGS: ['script', 'style', 'iframe', 'object', 'embed', 'img', 'svg', 'math']
+            });
+        }
+    </script>
     {% block head %}{% endblock %}
 </head>
 <body class="h-full bg-gray-50 text-gray-900">

--- a/src/workshop/templates/module1.html
+++ b/src/workshop/templates/module1.html
@@ -301,6 +301,9 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
     ],
     diResult: null, cuResult: null, prebuiltResult: null,
     loading: false, selectedSample: '',
+    sourceMode: 'sample', uploadedFile: null, uploadError: '', uploadPreviewUrl: null,
+    uploadLimitBytes: 10 * 1024 * 1024,
+    acceptedExtensions: ['.pdf', '.jpeg', '.jpg', '.png', '.bmp', '.tiff', '.tif', '.heif', '.heic', '.docx', '.xlsx', '.pptx', '.html'],
     diDone: false, cuDone: false, prebuiltDone: false,
     startTime: null, elapsed: '0.0', timer: null,
     hasError(r) { return r?.error || r?.trace?.error },
@@ -317,22 +320,81 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
     get hasNativePrebuiltModel() {
         return this.prebuiltModel !== 'prebuilt-layout';
     },
+    get selectedFilename() {
+        return this.sourceMode === 'upload' ? (this.uploadedFile?.name || '') : this.selectedSample;
+    },
+    get canAnalyze() {
+        return this.sourceMode === 'upload' ? !!this.uploadedFile && !this.uploadError : !!this.selectedSample;
+    },
+    selectSample(name) {
+        this.sourceMode = 'sample';
+        this.selectedSample = name;
+        this.clearUpload();
+    },
+    clearUpload() {
+        if (this.uploadPreviewUrl) URL.revokeObjectURL(this.uploadPreviewUrl);
+        this.uploadedFile = null;
+        this.uploadError = '';
+        this.uploadPreviewUrl = null;
+    },
+    handleUpload(event) {
+        const file = event.target.files?.[0];
+        this.clearUpload();
+        if (!file) return;
+        const ext = file.name.includes('.') ? '.' + file.name.split('.').pop().toLowerCase() : '';
+        if (!this.acceptedExtensions.includes(ext)) {
+            this.uploadError = 'Unsupported file type. Use PDF, image, Office, or HTML documents.';
+            return;
+        }
+        if (file.size > this.uploadLimitBytes) {
+            this.uploadError = 'File exceeds the 10 MB upload limit.';
+            return;
+        }
+        this.sourceMode = 'upload';
+        this.selectedSample = '';
+        this.uploadedFile = file;
+        if (file.type === 'application/pdf' || file.type.startsWith('image/')) {
+            this.uploadPreviewUrl = URL.createObjectURL(file);
+        }
+    },
+    buildDocumentRequest(url) {
+        if (this.sourceMode === 'upload') {
+            const form = new FormData();
+            form.append('file', this.uploadedFile);
+            return fetch(url, { method: 'POST', body: form });
+        }
+        return fetch(url + '?sample=' + encodeURIComponent(this.selectedSample), { method: 'POST' });
+    },
+    isPreviewImage() {
+        const name = this.selectedFilename.toLowerCase();
+        return this.sourceMode === 'upload'
+            ? this.uploadedFile?.type?.startsWith('image/')
+            : name.endsWith('.png') || name.endsWith('.jpg') || name.endsWith('.jpeg');
+    },
+    isPreviewPdf() {
+        return this.selectedFilename.toLowerCase().endsWith('.pdf');
+    },
+    previewSrc() {
+        return this.sourceMode === 'upload'
+            ? this.uploadPreviewUrl
+            : '/api/documents/samples/' + this.selectedSample + '/raw';
+    },
     startAnalysis() {
-        if (!this.selectedSample) return;
+        if (!this.canAnalyze) return;
         this.loading = true;
         this.diResult = null; this.cuResult = null; this.prebuiltResult = null;
         this.diDone = false; this.cuDone = false; this.prebuiltDone = false;
         this.startTime = Date.now();
         this.timer = setInterval(() => { this.elapsed = ((Date.now() - this.startTime) / 1000).toFixed(1); }, 100);
-        fetch('/api/di/layout?sample=' + this.selectedSample, { method: 'POST' })
+        this.buildDocumentRequest('/api/di/layout')
             .then(r => { if (!r.ok) return r.text().then(t => { throw new Error(t || 'HTTP ' + r.status) }); return r.json(); })
             .then(d => { this.diResult = d; this.diDone = true; this.checkDone(); })
             .catch(e => { this.diResult = { error: e.message }; this.diDone = true; this.checkDone(); });
-        fetch('/api/cu/layout?sample=' + this.selectedSample, { method: 'POST' })
+        this.buildDocumentRequest('/api/cu/layout')
             .then(r => { if (!r.ok) return r.text().then(t => { throw new Error(t || 'HTTP ' + r.status) }); return r.json(); })
             .then(d => { this.cuResult = d; this.cuDone = true; this.checkDone(); })
             .catch(e => { this.cuResult = { error: e.message }; this.cuDone = true; this.checkDone(); });
-        fetch('/api/di/prebuilt/' + this.prebuiltModel + '?sample=' + this.selectedSample, { method: 'POST' })
+        this.buildDocumentRequest('/api/di/prebuilt/' + this.prebuiltModel)
             .then(r => { if (!r.ok) return r.text().then(t => { throw new Error(t || 'HTTP ' + r.status) }); return r.json(); })
             .then(d => { this.prebuiltResult = d; this.prebuiltDone = true; this.checkDone(); })
             .catch(e => { this.prebuiltResult = { error: e.message }; this.prebuiltDone = true; this.checkDone(); });
@@ -367,8 +429,8 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
         <h2 class="text-lg font-semibold mb-4">📄 Choose a Document</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
             <template x-for="sample in samples" :key="sample.name">
-                <button @click="selectedSample = sample.name"
-                    :class="selectedSample === sample.name ? 'ring-2 ring-blue-500 bg-blue-50 border-blue-300' : 'bg-gray-50 hover:bg-gray-100 border-gray-200'"
+                <button @click="selectSample(sample.name)"
+                    :class="sourceMode === 'sample' && selectedSample === sample.name ? 'ring-2 ring-blue-500 bg-blue-50 border-blue-300' : 'bg-gray-50 hover:bg-gray-100 border-gray-200'"
                     class="border rounded-xl px-4 py-3 text-left transition-all">
                     <div class="flex items-start justify-between gap-3">
                         <div>
@@ -383,6 +445,27 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
                     </div>
                 </button>
             </template>
+        </div>
+        <div class="mt-4 border-2 border-dashed rounded-xl p-4"
+             :class="sourceMode === 'upload' ? 'border-blue-300 bg-blue-50' : 'border-gray-200 bg-gray-50'">
+            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                <div>
+                    <h3 class="font-semibold text-sm text-gray-900">Upload your own document</h3>
+                    <p class="text-xs text-gray-500 mt-1">
+                        Ephemeral request only. Max 10 MB. Supports PDF, images, Office documents, and HTML.
+                    </p>
+                    <p x-show="uploadedFile" class="text-xs text-blue-700 mt-2">
+                        Selected: <span class="font-mono" x-text="uploadedFile?.name"></span>
+                    </p>
+                    <p x-show="uploadError" class="text-xs text-red-700 mt-2" x-text="uploadError"></p>
+                </div>
+                <label class="inline-flex items-center justify-center px-4 py-2 bg-white border border-blue-200 text-blue-700 rounded-lg text-sm font-medium hover:bg-blue-50 cursor-pointer">
+                    Choose file
+                    <input type="file" class="sr-only"
+                           accept=".pdf,.jpeg,.jpg,.png,.bmp,.tiff,.tif,.heif,.heic,.docx,.xlsx,.pptx,.html"
+                           @change="handleUpload($event)" />
+                </label>
+            </div>
         </div>
         <!-- What to look for -->
         <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 mt-4">
@@ -405,7 +488,7 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
                 <p class="text-xs text-sky-700 mt-2" x-text="selectedDoc.comparisonHint"></p>
             </div>
         </template>
-        <button @click="startAnalysis()" :disabled="!selectedSample || loading"
+        <button @click="startAnalysis()" :disabled="!canAnalyze || loading"
             class="mt-4 px-6 py-2.5 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all">
             <span x-show="!loading">▶️ Run Analysis — Compare DI vs CU</span>
             <span x-show="loading" class="flex items-center gap-2">
@@ -435,19 +518,25 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
     </div>
 
     <!-- Document Preview -->
-    <div x-show="selectedSample" x-transition class="bg-white rounded-lg shadow p-6 mb-6">
+    <div x-show="canAnalyze" x-transition class="bg-white rounded-lg shadow p-6 mb-6">
         <h2 class="text-lg font-semibold mb-2">
             👁️ Source Document
-            <span x-show="selectedDoc" class="text-base font-normal text-gray-500" x-text="selectedDoc ? '- ' + selectedDoc.label : ''"></span>
+            <span class="text-base font-normal text-gray-500" x-text="selectedDoc ? '- ' + selectedDoc.label : '- ' + selectedFilename"></span>
         </h2>
         <p x-show="selectedDoc" class="text-sm text-gray-500 mb-3" x-text="selectedDoc ? selectedDoc.note : ''"></p>
+        <p x-show="sourceMode === 'upload'" class="text-sm text-amber-700 mb-3">
+            Uploaded files are analyzed from this browser request and are not stored by the workshop app.
+        </p>
         <div class="border rounded-lg overflow-hidden bg-gray-100 flex justify-center" style="max-height: 400px;">
-            <img x-show="selectedSample.endsWith('.png') || selectedSample.endsWith('.jpg')"
-                 :src="selectedSample ? '/api/documents/samples/' + selectedSample + '/raw' : null"
+            <img x-show="isPreviewImage()"
+                 :src="isPreviewImage() ? previewSrc() : null"
                  class="max-h-96 object-contain" alt="Document preview" />
-            <iframe x-show="selectedSample.endsWith('.pdf')"
-                    :src="selectedSample && selectedSample.endsWith('.pdf') ? '/api/documents/samples/' + selectedSample + '/raw' : null"
+            <iframe x-show="isPreviewPdf()"
+                    :src="isPreviewPdf() ? previewSrc() : null"
                     class="w-full" style="height: 400px;" title="PDF preview"></iframe>
+            <div x-show="!isPreviewImage() && !isPreviewPdf()" class="p-8 text-center text-sm text-gray-600">
+                Preview is not available for this file type. The file will still be sent to the analysis APIs.
+            </div>
         </div>
     </div>
 
@@ -557,7 +646,7 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
                                 class="text-xs px-2 py-1 bg-gray-100 text-gray-700 rounded hover:bg-gray-200">{ } Raw</button>
                         </div>
                         <div x-ref="cuRendered" class="rendered-md bg-gray-50 p-3 rounded overflow-auto max-h-80"
-                             x-html="typeof marked !== 'undefined' && cuResult.result?.content ? marked.parse(cuResult.result.content.substring(0, 3000)) : (cuResult.result?.content?.substring(0, 3000) || 'No content')"></div>
+                             x-html="safeMarkdown(cuResult.result?.content)"></div>
                         <pre x-ref="cuRaw" class="hidden bg-gray-50 p-3 rounded text-xs overflow-auto max-h-80"
                              x-text="JSON.stringify(cuResult.result, null, 2)?.substring(0, 5000)"></pre>
                     </div>

--- a/src/workshop/templates/module2.html
+++ b/src/workshop/templates/module2.html
@@ -298,6 +298,9 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
 <div x-data="{
     diResult: null, cuResult: null, loading: false,
     selectedSample: 'contract.pdf',
+    sourceMode: 'sample', uploadedFile: null, uploadError: '', uploadPreviewUrl: null,
+    uploadLimitBytes: 10 * 1024 * 1024,
+    acceptedExtensions: ['.pdf', '.jpeg', '.jpg', '.png', '.bmp', '.tiff', '.tif', '.heif', '.heic', '.docx', '.xlsx', '.pptx', '.html'],
     diDone: false, cuDone: false, startTime: null, elapsed: '0.0', timer: null,
     hasError(r) { return r?.error || r?.trace?.error },
     getError(r) { return r?.error || r?.trace?.error },
@@ -332,19 +335,101 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
             { name: 'payment_terms', type: 'string', description: 'Payment terms (e.g., Net 30)' },
             { name: 'delivery_date', type: 'string', description: 'Expected delivery date' },
         ],
+        'upload': [
+            { name: 'summary', type: 'string', description: 'A 2-3 sentence summary of the document' },
+            { name: 'key_parties', type: 'string', description: 'People, organizations, or departments mentioned' },
+            { name: 'key_dates', type: 'string', description: 'Important dates, deadlines, or effective periods' },
+            { name: 'action_items', type: 'string', description: 'Tasks, obligations, or follow-up actions' },
+            { name: 'risk_level', type: 'string', description: 'Overall risk level: low, medium, or high' },
+        ],
     },
     switchFieldPreset(preset) {
         if (this.fieldPresets[preset]) {
             this.fields = JSON.parse(JSON.stringify(this.fieldPresets[preset]));
         }
     },
+    get selectedFilename() {
+        return this.sourceMode === 'upload' ? (this.uploadedFile?.name || '') : this.selectedSample;
+    },
+    get canAnalyze() {
+        return this.sourceMode === 'upload' ? !!this.uploadedFile && !this.uploadError : !!this.selectedSample;
+    },
+    selectSample(name, preset) {
+        this.sourceMode = 'sample';
+        this.selectedSample = name;
+        this.clearUpload();
+        this.switchFieldPreset(preset);
+    },
+    clearUpload() {
+        if (this.uploadPreviewUrl) URL.revokeObjectURL(this.uploadPreviewUrl);
+        this.uploadedFile = null;
+        this.uploadError = '';
+        this.uploadPreviewUrl = null;
+    },
+    handleUpload(event) {
+        const file = event.target.files?.[0];
+        this.clearUpload();
+        if (!file) return;
+        const ext = file.name.includes('.') ? '.' + file.name.split('.').pop().toLowerCase() : '';
+        if (!this.acceptedExtensions.includes(ext)) {
+            this.uploadError = 'Unsupported file type. Use PDF, image, Office, or HTML documents.';
+            return;
+        }
+        if (file.size > this.uploadLimitBytes) {
+            this.uploadError = 'File exceeds the 10 MB upload limit.';
+            return;
+        }
+        this.sourceMode = 'upload';
+        this.selectedSample = '';
+        this.uploadedFile = file;
+        this.switchFieldPreset('upload');
+        if (file.type === 'application/pdf' || file.type.startsWith('image/')) {
+            this.uploadPreviewUrl = URL.createObjectURL(file);
+        }
+    },
+    buildDocumentRequest(url) {
+        if (this.sourceMode === 'upload') {
+            const form = new FormData();
+            form.append('file', this.uploadedFile);
+            return fetch(url, { method: 'POST', body: form });
+        }
+        return fetch(url + '?sample=' + encodeURIComponent(this.selectedSample), { method: 'POST' });
+    },
+    buildCustomRequest(analyzerId) {
+        if (this.sourceMode === 'upload') {
+            const form = new FormData();
+            form.append('file', this.uploadedFile);
+            form.append('fields', JSON.stringify(this.fields));
+            form.append('analyzer_id', analyzerId);
+            return fetch('/api/cu/custom', { method: 'POST', body: form });
+        }
+        return fetch('/api/cu/custom', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sample: this.selectedSample, fields: this.fields, analyzer_id: analyzerId })
+        });
+    },
+    isPreviewImage() {
+        const name = this.selectedFilename.toLowerCase();
+        return this.sourceMode === 'upload'
+            ? this.uploadedFile?.type?.startsWith('image/')
+            : name.endsWith('.png') || name.endsWith('.jpg') || name.endsWith('.jpeg');
+    },
+    isPreviewPdf() {
+        return this.selectedFilename.toLowerCase().endsWith('.pdf');
+    },
+    previewSrc() {
+        return this.sourceMode === 'upload'
+            ? this.uploadPreviewUrl
+            : '/api/documents/samples/' + this.selectedSample + '/raw';
+    },
     startAnalysis() {
-        if (!this.selectedSample) return;
+        if (!this.canAnalyze) return;
         this.loading = true; this.diResult = null; this.cuResult = null;
         this.diDone = false; this.cuDone = false;
         this.startTime = Date.now();
         this.timer = setInterval(() => { this.elapsed = ((Date.now() - this.startTime) / 1000).toFixed(1); }, 100);
-        fetch('/api/di/layout?sample=' + this.selectedSample, { method: 'POST' })
+        this.buildDocumentRequest('/api/di/layout')
             .then(r => { if (!r.ok) return r.text().then(t => { throw new Error(t || 'HTTP ' + r.status) }); return r.json(); })
             .then(d => { this.diResult = d; this.diDone = true; this.checkDone(); })
             .catch(e => { this.diResult = { error: e.message }; this.diDone = true; this.checkDone(); });
@@ -352,11 +437,7 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
         let hash = 0;
         for (let i = 0; i < schema.length; i++) { hash = ((hash << 5) - hash + schema.charCodeAt(i)) | 0; }
         const analyzerId = 'workshop_' + Math.abs(hash).toString(36);
-        fetch('/api/cu/custom', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ sample: this.selectedSample, fields: this.fields, analyzer_id: analyzerId })
-        })
+        this.buildCustomRequest(analyzerId)
         .then(r => { if (!r.ok) return r.text().then(t => { throw new Error(t || 'HTTP ' + r.status) }); return r.json(); })
         .then(d => { this.cuResult = d; this.cuDone = true; this.checkDone(); })
         .catch(e => { this.cuResult = { error: e.message }; this.cuDone = true; this.checkDone(); });
@@ -368,22 +449,43 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
     <div class="bg-white rounded-lg shadow p-6 mb-6">
         <h2 class="text-lg font-semibold mb-4">📄 Choose an Unstructured Document</h2>
         <div class="flex flex-wrap gap-3">
-            <button @click="if (selectedSample !== 'contract.pdf') { selectedSample = 'contract.pdf'; switchFieldPreset('contract'); }"
-                :class="selectedSample === 'contract.pdf' ? 'ring-2 ring-purple-500 bg-purple-50' : 'bg-gray-100 hover:bg-gray-200'"
+            <button @click="selectSample('contract.pdf', 'contract')"
+                :class="sourceMode === 'sample' && selectedSample === 'contract.pdf' ? 'ring-2 ring-purple-500 bg-purple-50' : 'bg-gray-100 hover:bg-gray-200'"
                 class="px-4 py-2 rounded-lg text-sm font-medium transition-all">
                 📜 Contract (PDF)
             </button>
-            <button @click="if (selectedSample !== 'purchase-order.pdf') { selectedSample = 'purchase-order.pdf'; switchFieldPreset('purchase-order'); }"
-                :class="selectedSample === 'purchase-order.pdf' ? 'ring-2 ring-purple-500 bg-purple-50' : 'bg-gray-100 hover:bg-gray-200'"
+            <button @click="selectSample('purchase-order.pdf', 'purchase-order')"
+                :class="sourceMode === 'sample' && selectedSample === 'purchase-order.pdf' ? 'ring-2 ring-purple-500 bg-purple-50' : 'bg-gray-100 hover:bg-gray-200'"
                 class="px-4 py-2 rounded-lg text-sm font-medium transition-all">
                 🧾 Purchase Order (PDF)
             </button>
+        </div>
+        <div class="mt-4 border-2 border-dashed rounded-xl p-4"
+             :class="sourceMode === 'upload' ? 'border-purple-300 bg-purple-50' : 'border-gray-200 bg-gray-50'">
+            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                <div>
+                    <h3 class="font-semibold text-sm text-gray-900">Upload your own document</h3>
+                    <p class="text-xs text-gray-500 mt-1">
+                        Ephemeral analysis request. Max 10 MB. The generic semantic field preset is applied automatically.
+                    </p>
+                    <p x-show="uploadedFile" class="text-xs text-purple-700 mt-2">
+                        Selected: <span class="font-mono" x-text="uploadedFile?.name"></span>
+                    </p>
+                    <p x-show="uploadError" class="text-xs text-red-700 mt-2" x-text="uploadError"></p>
+                </div>
+                <label class="inline-flex items-center justify-center px-4 py-2 bg-white border border-purple-200 text-purple-700 rounded-lg text-sm font-medium hover:bg-purple-50 cursor-pointer">
+                    Choose file
+                    <input type="file" class="sr-only"
+                           accept=".pdf,.jpeg,.jpg,.png,.bmp,.tiff,.tif,.heif,.heic,.docx,.xlsx,.pptx,.html"
+                           @change="handleUpload($event)" />
+                </label>
+            </div>
         </div>
         <p class="text-sm text-gray-500 mt-3">
             DI extracts raw text and detects table structures. CU uses GenAI to infer meaning — fields switch automatically based on document type.
         </p>
         <p class="mt-3 text-xs text-gray-500 italic">Both services run on the same document so you can compare. In production, CU alone handles this type of extraction.</p>
-        <button @click="startAnalysis()" :disabled="!selectedSample || loading"
+        <button @click="startAnalysis()" :disabled="!canAnalyze || loading"
             class="mt-3 px-6 py-2.5 bg-purple-600 text-white rounded-lg font-medium hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all">
             <span x-show="!loading">▶️ Run Analysis — Compare DI vs CU</span>
             <span x-show="loading" class="flex items-center gap-2">
@@ -410,9 +512,17 @@ pip install azure-ai-documentintelligence azure-ai-contentunderstanding azure-id
 
     <!-- Document Preview -->
     <div class="bg-white rounded-lg shadow p-6 mb-6">
-        <h2 class="text-lg font-semibold mb-3">👁️ Source Document — <span x-text="selectedSample"></span></h2>
+        <h2 class="text-lg font-semibold mb-3">👁️ Source Document — <span x-text="selectedFilename"></span></h2>
+        <p x-show="sourceMode === 'upload'" class="text-sm text-amber-700 mb-3">
+            Uploaded files are analyzed from this browser request and are not stored by the workshop app.
+        </p>
         <div class="border rounded-lg overflow-hidden bg-gray-100" style="height: 300px;">
-            <iframe :src="selectedSample ? '/api/documents/samples/' + selectedSample + '/raw' : null" class="w-full h-full"></iframe>
+            <img x-show="isPreviewImage()" :src="isPreviewImage() ? previewSrc() : null"
+                 class="h-full mx-auto object-contain" alt="Document preview" />
+            <iframe x-show="isPreviewPdf()" :src="isPreviewPdf() ? previewSrc() : null" class="w-full h-full"></iframe>
+            <div x-show="!isPreviewImage() && !isPreviewPdf()" class="h-full flex items-center justify-center text-sm text-gray-600 text-center p-6">
+                Preview is not available for this file type. The file will still be sent to the analysis APIs.
+            </div>
         </div>
     </div>
 

--- a/src/workshop/templates/module3.html
+++ b/src/workshop/templates/module3.html
@@ -173,6 +173,10 @@ curl "https://&lt;search-service&gt;.search.windows.net/indexes/documents/docs/s
 <div x-data="{
     indexing: false, searching: false,
     selectedSample: '', indexResult: null, searchResult: null,
+    sourceMode: 'sample', uploadedFile: null, uploadError: '',
+    uploadScope: '',
+    uploadLimitBytes: 10 * 1024 * 1024,
+    acceptedExtensions: ['.pdf', '.jpeg', '.jpg', '.png', '.bmp', '.tiff', '.tif', '.heif', '.heic', '.docx', '.xlsx', '.pptx', '.html'],
     searchQuery: '', statsResult: null, statsTimeout: null,
     indexDone: false, startTime: null, elapsed: '0.0', timer: null,
     hasError(r) { return r?.error || r?.trace?.error || r?.trace?.cu?.error || r?.trace?.search?.error },
@@ -183,8 +187,60 @@ curl "https://&lt;search-service&gt;.search.windows.net/indexes/documents/docs/s
         if (r?.trace?.search?.error) return r.trace.search.error;
         return 'Unknown error';
     },
+    ensureUploadScope() {
+        let scope = localStorage.getItem('workshopUploadScope');
+        if (!scope) {
+            scope = (window.crypto?.randomUUID?.() || ('scope-' + Math.random().toString(36).slice(2) + Date.now().toString(36)));
+            localStorage.setItem('workshopUploadScope', scope);
+        }
+        this.uploadScope = scope;
+        return scope;
+    },
+    get selectedFilename() {
+        return this.sourceMode === 'upload' ? (this.uploadedFile?.name || '') : this.selectedSample;
+    },
+    get canIndex() {
+        return this.sourceMode === 'upload' ? !!this.uploadedFile && !this.uploadError : !!this.selectedSample;
+    },
+    selectSample(name) {
+        this.sourceMode = 'sample';
+        this.selectedSample = name;
+        this.uploadedFile = null;
+        this.uploadError = '';
+    },
+    handleUpload(event) {
+        const file = event.target.files?.[0];
+        this.uploadedFile = null;
+        this.uploadError = '';
+        if (!file) return;
+        const ext = file.name.includes('.') ? '.' + file.name.split('.').pop().toLowerCase() : '';
+        if (!this.acceptedExtensions.includes(ext)) {
+            this.uploadError = 'Unsupported file type. Use PDF, image, Office, or HTML documents.';
+            return;
+        }
+        if (file.size > this.uploadLimitBytes) {
+            this.uploadError = 'File exceeds the 10 MB upload limit.';
+            return;
+        }
+        this.sourceMode = 'upload';
+        this.selectedSample = '';
+        this.uploadedFile = file;
+    },
+    buildIndexRequest() {
+        if (this.sourceMode === 'upload') {
+            const form = new FormData();
+            form.append('file', this.uploadedFile);
+            form.append('upload_scope', this.ensureUploadScope());
+            return fetch('/api/search/index', { method: 'POST', body: form });
+        }
+        return fetch('/api/search/index', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sample: this.selectedSample })
+        });
+    },
     async ensureAndIndex() {
-        if (!this.selectedSample) return;
+        if (!this.canIndex) return;
         this.indexing = true; this.indexResult = null;
         this.startTime = Date.now();
         this.timer = setInterval(() => { this.elapsed = ((Date.now() - this.startTime) / 1000).toFixed(1); }, 100);
@@ -195,11 +251,7 @@ curl "https://&lt;search-service&gt;.search.windows.net/indexes/documents/docs/s
             if (!ensureResp.ok) { const t = await ensureResp.text(); throw new Error(t || 'HTTP ' + ensureResp.status); }
 
             // Index the document (CU enrichment + push)
-            const resp = await fetch('/api/search/index', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ sample: this.selectedSample })
-            });
+            const resp = await this.buildIndexRequest();
             if (!resp.ok) { const t = await resp.text(); throw new Error(t || 'HTTP ' + resp.status); }
             this.indexResult = await resp.json();
         } catch (e) {
@@ -217,7 +269,7 @@ curl "https://&lt;search-service&gt;.search.windows.net/indexes/documents/docs/s
             const resp = await fetch('/api/search/query', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ query: this.searchQuery, top: 5, use_semantic: true })
+                body: JSON.stringify({ query: this.searchQuery, top: 5, use_semantic: true, upload_scope: this.ensureUploadScope() })
             });
             if (!resp.ok) { const t = await resp.text(); throw new Error(t || 'HTTP ' + resp.status); }
             this.searchResult = await resp.json();
@@ -232,7 +284,7 @@ curl "https://&lt;search-service&gt;.search.windows.net/indexes/documents/docs/s
             if (resp.ok) this.statsResult = await resp.json();
         } catch (e) { /* ignore */ }
     }
-}" x-init="refreshStats()" x-cloak>
+}" x-init="ensureUploadScope(); refreshStats()" x-cloak>
 
     <!-- Step 1: Index a document -->
     <div class="bg-white rounded-lg shadow p-6 mb-6">
@@ -241,21 +293,42 @@ curl "https://&lt;search-service&gt;.search.windows.net/indexes/documents/docs/s
             Select a document. CU will extract a summary and key topics, then push the enriched document to Azure AI Search.
         </p>
         <div class="flex flex-wrap gap-3 mb-4">
-            <button @click="selectedSample = 'contract.pdf'"
-                :class="selectedSample === 'contract.pdf' ? 'ring-2 ring-indigo-500 bg-indigo-50' : 'bg-gray-100 hover:bg-gray-200'"
+            <button @click="selectSample('contract.pdf')"
+                :class="sourceMode === 'sample' && selectedSample === 'contract.pdf' ? 'ring-2 ring-indigo-500 bg-indigo-50' : 'bg-gray-100 hover:bg-gray-200'"
                 class="px-4 py-2 rounded-lg text-sm font-medium transition-all">
                 📜 Contract (PDF)
             </button>
-            <button @click="selectedSample = 'invoice.pdf'"
-                :class="selectedSample === 'invoice.pdf' ? 'ring-2 ring-indigo-500 bg-indigo-50' : 'bg-gray-100 hover:bg-gray-200'"
+            <button @click="selectSample('invoice.pdf')"
+                :class="sourceMode === 'sample' && selectedSample === 'invoice.pdf' ? 'ring-2 ring-indigo-500 bg-indigo-50' : 'bg-gray-100 hover:bg-gray-200'"
                 class="px-4 py-2 rounded-lg text-sm font-medium transition-all">
                 📄 Invoice (PDF)
             </button>
-            <button @click="selectedSample = 'receipt.png'"
-                :class="selectedSample === 'receipt.png' ? 'ring-2 ring-indigo-500 bg-indigo-50' : 'bg-gray-100 hover:bg-gray-200'"
+            <button @click="selectSample('receipt.png')"
+                :class="sourceMode === 'sample' && selectedSample === 'receipt.png' ? 'ring-2 ring-indigo-500 bg-indigo-50' : 'bg-gray-100 hover:bg-gray-200'"
                 class="px-4 py-2 rounded-lg text-sm font-medium transition-all">
                 🧾 Receipt (PNG)
             </button>
+        </div>
+        <div class="border-2 border-dashed rounded-xl p-4 mb-4"
+             :class="sourceMode === 'upload' ? 'border-indigo-300 bg-indigo-50' : 'border-gray-200 bg-gray-50'">
+            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                <div>
+                    <h3 class="font-semibold text-sm text-gray-900">Upload and index your own document</h3>
+                    <p class="text-xs text-amber-700 mt-1">
+                        Module 3 writes extracted content and metadata into Azure AI Search. Raw uploaded files are not stored by the app.
+                    </p>
+                    <p x-show="uploadedFile" class="text-xs text-indigo-700 mt-2">
+                        Selected: <span class="font-mono" x-text="uploadedFile?.name"></span>
+                    </p>
+                    <p x-show="uploadError" class="text-xs text-red-700 mt-2" x-text="uploadError"></p>
+                </div>
+                <label class="inline-flex items-center justify-center px-4 py-2 bg-white border border-indigo-200 text-indigo-700 rounded-lg text-sm font-medium hover:bg-indigo-50 cursor-pointer">
+                    Choose file
+                    <input type="file" class="sr-only"
+                           accept=".pdf,.jpeg,.jpg,.png,.bmp,.tiff,.tif,.heif,.heic,.docx,.xlsx,.pptx,.html"
+                           @change="handleUpload($event)" />
+                </label>
+            </div>
         </div>
 
         <!-- Index stats badge -->
@@ -274,7 +347,7 @@ curl "https://&lt;search-service&gt;.search.windows.net/indexes/documents/docs/s
             </ul>
         </div>
 
-        <button @click="ensureAndIndex()" :disabled="!selectedSample || indexing"
+        <button @click="ensureAndIndex()" :disabled="!canIndex || indexing"
             class="px-6 py-2.5 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all">
             <span x-show="!indexing">📥 Enrich & Index Document</span>
             <span x-show="indexing" class="flex items-center gap-2">

--- a/src/workshop/templates/module4.html
+++ b/src/workshop/templates/module4.html
@@ -169,21 +169,82 @@ MaxQueueLength=500</code></pre>
 <!-- Interactive Demo -->
 <div x-data="{
     processing: false, batchResult: null,
+    samples: ['contract.pdf', 'invoice.pdf', 'receipt.png'],
+    uploadedFiles: [], uploadError: '',
+    uploadScope: '',
+    uploadLimitBytes: 10 * 1024 * 1024,
+    maxBatchSize: 20,
+    acceptedExtensions: ['.pdf', '.jpeg', '.jpg', '.png', '.bmp', '.tiff', '.tif', '.heif', '.heic', '.docx', '.xlsx', '.pptx', '.html'],
     startTime: null, elapsed: '0.0', timer: null,
     currentDoc: '', completedDocs: 0, totalDocs: 0,
     hasError(r) { return r?.error },
+    get queuedDocumentNames() {
+        return [...this.samples, ...this.uploadedFiles.map((file) => file.name)];
+    },
+    get canRunBatch() {
+        return this.queuedDocumentNames.length > 0 && this.queuedDocumentNames.length <= this.maxBatchSize && !this.uploadError;
+    },
+    ensureUploadScope() {
+        let scope = localStorage.getItem('workshopUploadScope');
+        if (!scope) {
+            scope = (window.crypto?.randomUUID?.() || ('scope-' + Math.random().toString(36).slice(2) + Date.now().toString(36)));
+            localStorage.setItem('workshopUploadScope', scope);
+        }
+        this.uploadScope = scope;
+        return scope;
+    },
+    handleUpload(event) {
+        this.uploadError = '';
+        const files = Array.from(event.target.files || []);
+        for (const file of files) {
+            const ext = file.name.includes('.') ? '.' + file.name.split('.').pop().toLowerCase() : '';
+            if (!this.acceptedExtensions.includes(ext)) {
+                this.uploadError = 'Unsupported file type. Use PDF, image, Office, or HTML documents.';
+                continue;
+            }
+            if (file.size > this.uploadLimitBytes) {
+                this.uploadError = file.name + ' exceeds the 10 MB upload limit.';
+                continue;
+            }
+            if (this.queuedDocumentNames.includes(file.name)) {
+                this.uploadError = file.name + ' is already in the batch queue.';
+                continue;
+            }
+            if (this.queuedDocumentNames.length >= this.maxBatchSize) {
+                this.uploadError = 'Batch size cannot exceed ' + this.maxBatchSize + ' documents.';
+                break;
+            }
+            this.uploadedFiles.push(file);
+        }
+        event.target.value = '';
+    },
+    removeUpload(index) {
+        this.uploadedFiles.splice(index, 1);
+        this.uploadError = '';
+    },
+    buildBatchRequest() {
+        if (this.uploadedFiles.length) {
+            const form = new FormData();
+            form.append('samples', JSON.stringify(this.samples));
+            form.append('upload_scope', this.ensureUploadScope());
+            this.uploadedFiles.forEach((file) => form.append('files', file));
+            return fetch('/api/batch/process', { method: 'POST', body: form });
+        }
+        return fetch('/api/batch/process', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ samples: this.samples })
+        });
+    },
     async runBatch() {
+        if (!this.canRunBatch) return;
         this.processing = true; this.batchResult = null;
-        this.completedDocs = 0; this.totalDocs = 3;
+        this.completedDocs = 0; this.totalDocs = this.queuedDocumentNames.length;
         this.startTime = Date.now();
         this.timer = setInterval(() => { this.elapsed = ((Date.now() - this.startTime) / 1000).toFixed(1); }, 100);
 
         try {
-            const resp = await fetch('/api/batch/process', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ samples: ['contract.pdf', 'invoice.pdf', 'receipt.png'] })
-            });
+            const resp = await this.buildBatchRequest();
             if (!resp.ok) { const t = await resp.text(); throw new Error(t || 'HTTP ' + resp.status); }
             this.batchResult = await resp.json();
         } catch (e) {
@@ -191,15 +252,53 @@ MaxQueueLength=500</code></pre>
         }
         this.processing = false; clearInterval(this.timer);
     }
-}" x-cloak>
+}" x-init="ensureUploadScope()" x-cloak>
 
     <!-- Batch Controls -->
     <div class="bg-white rounded-lg shadow p-6 mb-6">
         <h2 class="text-lg font-semibold mb-4">🚀 Batch Process All Documents</h2>
         <p class="text-sm text-gray-600 mb-4">
-            Process all 3 workshop documents through the full pipeline: CU enrichment (summary + key topics) → AI Search indexing.
+            Process the workshop documents plus optional uploads through the full pipeline: CU enrichment (summary + key topics) → AI Search indexing.
             In production, this would run through SimpleL7Proxy routing to PTU for cost savings.
         </p>
+        <div class="border-2 border-dashed rounded-xl p-4 mb-4"
+             :class="uploadedFiles.length ? 'border-rose-300 bg-rose-50' : 'border-gray-200 bg-gray-50'">
+            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                <div>
+                    <h3 class="font-semibold text-sm text-gray-900">Add uploaded documents to the batch</h3>
+                    <p class="text-xs text-amber-700 mt-1">
+                        Batch uploads are processed request-by-request, but extracted content and metadata are written to Azure AI Search.
+                    </p>
+                    <p x-show="uploadError" class="text-xs text-red-700 mt-2" x-text="uploadError"></p>
+                </div>
+                <label class="inline-flex items-center justify-center px-4 py-2 bg-white border border-rose-200 text-rose-700 rounded-lg text-sm font-medium hover:bg-rose-50 cursor-pointer">
+                    Add files
+                    <input type="file" multiple class="sr-only"
+                           accept=".pdf,.jpeg,.jpg,.png,.bmp,.tiff,.tif,.heif,.heic,.docx,.xlsx,.pptx,.html"
+                           @change="handleUpload($event)" />
+                </label>
+            </div>
+        </div>
+
+        <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-4">
+            <h3 class="font-semibold text-sm text-gray-900 mb-2">Batch queue</h3>
+            <div class="flex flex-wrap gap-2">
+                <template x-for="sample in samples" :key="sample">
+                    <span class="text-xs px-2 py-1 rounded-full bg-white border border-gray-200 text-gray-700">
+                        Sample: <span class="font-mono" x-text="sample"></span>
+                    </span>
+                </template>
+                <template x-for="(file, index) in uploadedFiles" :key="file.name + ':' + file.size">
+                    <span class="inline-flex items-center gap-2 text-xs px-2 py-1 rounded-full bg-rose-100 border border-rose-200 text-rose-800">
+                        Upload: <span class="font-mono" x-text="file.name"></span>
+                        <button type="button" @click="removeUpload(index)" class="font-bold text-rose-700 hover:text-rose-900" aria-label="Remove uploaded file">×</button>
+                    </span>
+                </template>
+            </div>
+            <p class="text-xs text-gray-500 mt-2">
+                <span x-text="queuedDocumentNames.length"></span> / <span x-text="maxBatchSize"></span> documents queued.
+            </p>
+        </div>
 
         <!-- What to Look For -->
         <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-4">
@@ -213,7 +312,7 @@ MaxQueueLength=500</code></pre>
         </div>
 
         <div class="flex items-center gap-4">
-            <button @click="runBatch()" :disabled="processing"
+            <button @click="runBatch()" :disabled="processing || !canRunBatch"
                 class="px-6 py-2.5 bg-rose-600 text-white rounded-lg font-medium hover:bg-rose-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all">
                 <span x-show="!processing">⚡ Run Batch Pipeline</span>
                 <span x-show="processing" class="flex items-center gap-2">
@@ -228,7 +327,12 @@ MaxQueueLength=500</code></pre>
 
         <!-- Documents being processed -->
         <div class="mt-4 text-sm text-gray-500">
-            Documents: <span class="font-mono">contract.pdf</span>, <span class="font-mono">invoice.pdf</span>, <span class="font-mono">receipt.png</span>
+            Documents:
+            <template x-for="(name, index) in queuedDocumentNames" :key="name">
+                <span>
+                    <span x-show="index > 0">, </span><span class="font-mono" x-text="name"></span>
+                </span>
+            </template>
         </div>
     </div>
 

--- a/tests/e2e/analysis-workflow.spec.ts
+++ b/tests/e2e/analysis-workflow.spec.ts
@@ -1,5 +1,9 @@
 import { Route } from "@playwright/test";
+import path from "path";
 import { test, expect } from "./helpers";
+
+const uploadFixturePath = path.join(process.cwd(), "samples", "invoice.pdf");
+const batchUploadFixturePath = path.join(process.cwd(), "samples", "purchase-order.pdf");
 
 // --- Mock response fixtures ---
 
@@ -313,6 +317,67 @@ test.describe("Module 1 — Analysis Workflow", () => {
       page.getByText("No typed fields is the expected outcome here.")
     ).toBeVisible();
   });
+
+  test("uploaded document is sent as multipart form data", async ({
+    page, consoleErrors,
+  }) => {
+    await page.route("**/api/di/layout", (route) =>
+      mockRoute(route, mockDILayoutResult)
+    );
+    await page.route("**/api/cu/layout", (route) =>
+      mockRoute(route, mockCULayoutResult)
+    );
+    await page.route("**/api/di/prebuilt/*", (route) =>
+      mockRoute(route, mockDIPrebuiltResult)
+    );
+
+    await page.goto("/module/1");
+    await page.getByLabel("Choose file").setInputFiles(uploadFixturePath);
+    await expect(page.getByText("Selected:")).toBeVisible();
+
+    const uploadRequestPromise = page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/api/di/layout") && request.method() === "POST"
+    );
+
+    await page.getByRole("button", { name: /Run Analysis/i }).click();
+    const uploadRequest = await uploadRequestPromise;
+    expect(uploadRequest.headers()["content-type"]).toContain("multipart/form-data");
+
+    await expect(
+      page.getByText("Document Intelligence — Layout")
+    ).toBeVisible();
+    await expect(page.getByText("Analysis Failed")).not.toBeVisible();
+  });
+
+  test("uploaded CU markdown is sanitized before rendering", async ({
+    page, consoleErrors,
+  }) => {
+    await page.route("**/api/di/layout", (route) =>
+      mockRoute(route, mockDILayoutResult)
+    );
+    await page.route("**/api/cu/layout", (route) =>
+      mockRoute(route, {
+        result: {
+          content: "<img src=x onerror=\"console.error('xss')\"># Safe content",
+          contents: [{ markdown: "<img src=x onerror=\"console.error('xss')\"># Safe content" }],
+        },
+        trace: mockCULayoutResult.trace,
+      })
+    );
+    await page.route("**/api/di/prebuilt/*", (route) =>
+      mockRoute(route, mockDIPrebuiltResult)
+    );
+
+    await page.goto("/module/1");
+    await page.getByLabel("Choose file").setInputFiles(uploadFixturePath);
+    await page.getByRole("button", { name: /Run Analysis/i }).click();
+
+    await expect(page.getByText("Content Understanding — Layout")).toBeVisible();
+    const rendered = page.locator("[x-ref='cuRendered']");
+    await expect(rendered.getByText("Safe content")).toBeVisible();
+    await expect(rendered.locator("img[src='x']")).toHaveCount(0);
+  });
 });
 
 // ============================================================
@@ -343,6 +408,35 @@ test.describe("Module 2 — Analysis Workflow", () => {
     const cuHeading = page.getByText("CU — Semantic Extraction").first();
     const cuResultPanel = cuHeading.locator("..").locator("..");
     await expect(cuResultPanel.getByText("summary").first()).toBeVisible();
+    await expect(page.getByText("Analysis Failed")).not.toBeVisible();
+  });
+
+  test("uploaded document is sent to CU custom as multipart form data", async ({
+    page, consoleErrors,
+  }) => {
+    await page.route("**/api/di/layout", (route) =>
+      mockRoute(route, mockDILayoutResult)
+    );
+    await page.route("**/api/cu/custom", (route) =>
+      mockRoute(route, mockCUCustomResult)
+    );
+
+    await page.goto("/module/2");
+    await page.getByLabel("Choose file").setInputFiles(uploadFixturePath);
+    await expect(page.getByText("Selected:")).toBeVisible();
+
+    const cuRequestPromise = page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/api/cu/custom") && request.method() === "POST"
+    );
+
+    await page.getByRole("button", { name: /Compare|Analyze|Run/i }).click();
+    const cuRequest = await cuRequestPromise;
+    expect(cuRequest.headers()["content-type"]).toContain("multipart/form-data");
+
+    await expect(
+      page.getByText("CU — Semantic Extraction").first()
+    ).toBeVisible();
     await expect(page.getByText("Analysis Failed")).not.toBeVisible();
   });
 });
@@ -511,5 +605,59 @@ test.describe("Module 4 — Batch Workflow", () => {
     await traceDetails.locator("summary").click();
     await expect(traceDetails.getByText("CU Trace")).toBeVisible();
     await expect(traceDetails.getByText("Search Trace")).toBeVisible();
+  });
+
+  test("batch run with uploaded files uses multipart form data", async ({
+    page,
+    consoleErrors,
+  }) => {
+    await page.route("**/api/batch/process", async (route) => {
+      await delay(250);
+      await mockRoute(route, {
+        result: {
+          documents: [
+            ...mockBatchResult.result.documents,
+            {
+              sample: "invoice.pdf",
+              source_type: "upload",
+              document_id: "doc-upload-001",
+              cu_fields: {
+                summary: "Uploaded invoice for consulting services.",
+                key_topics: "invoice, upload",
+              },
+              cu_duration_ms: 1200,
+              search_duration_ms: 60,
+              cu_trace: { response_status: 200, duration_ms: 1200 },
+              search_trace: { response_status: 200, duration_ms: 60 },
+            },
+          ],
+          summary: {
+            total: 4,
+            succeeded: 4,
+            failed: 0,
+            total_cu_ms: 7000,
+            total_search_ms: 357,
+            total_ms: 7357,
+          },
+        },
+        trace: mockBatchResult.trace,
+      });
+    });
+
+    await page.goto("/module/4");
+    await page.getByLabel("Add files").setInputFiles(batchUploadFixturePath);
+    await expect(page.getByText("Upload:")).toBeVisible();
+
+    const batchRequestPromise = page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/api/batch/process") && request.method() === "POST"
+    );
+
+    await page.getByRole("button", { name: /Run Batch Pipeline/i }).click();
+    const batchRequest = await batchRequestPromise;
+    expect(batchRequest.headers()["content-type"]).toContain("multipart/form-data");
+
+    await expect(page.getByText("Batch Complete")).toBeVisible();
+    await expect(page.getByText("Uploaded invoice for consulting services.")).toBeVisible();
   });
 });

--- a/tests/e2e/module3.spec.ts
+++ b/tests/e2e/module3.spec.ts
@@ -1,5 +1,8 @@
 import { Route } from "@playwright/test";
+import path from "path";
 import { test, expect } from "./helpers";
+
+const uploadFixturePath = path.join(process.cwd(), "samples", "invoice.pdf");
 
 function mockJsonRoute(
   route: Route,
@@ -43,7 +46,7 @@ const initialStats = {
 const ensureIndexResult = {
   result: {
     name: "workshop-search",
-    fields: 7,
+    fields: 9,
   },
   trace: {
     url: "https://test.search.windows.net/indexes/workshop-search",
@@ -216,6 +219,46 @@ test.describe("Module 3 — Search Workflow", () => {
     await expect(traces.getByText("Search Trace")).toBeVisible();
   });
 
+  test("uploading and indexing a document sends multipart form data", async ({
+    page,
+    consoleErrors,
+  }) => {
+    await page.route("**/api/search/ensure-index", (route) =>
+      mockJsonRoute(route, ensureIndexResult)
+    );
+    await page.route("**/api/search/index", async (route) => {
+      await delay(250);
+      await mockJsonRoute(route, {
+        ...indexContractResult,
+        result: {
+          ...indexContractResult.result,
+          document_id: "doc-upload-001",
+          source_doc: "invoice.pdf",
+          source_type: "upload",
+        },
+      });
+    });
+
+    await page.goto("/module/3");
+    await page.getByLabel("Choose file").setInputFiles(uploadFixturePath);
+    await expect(page.getByText("Selected:")).toBeVisible();
+
+    const indexButton = page.getByRole("button", { name: /Enrich & Index Document/i });
+    await expect(indexButton).toBeEnabled();
+
+    const indexRequestPromise = page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/api/search/index") && request.method() === "POST"
+    );
+
+    await indexButton.click();
+    const indexRequest = await indexRequestPromise;
+    expect(indexRequest.headers()["content-type"]).toContain("multipart/form-data");
+
+    await expect(page.getByText("✅ Document Indexed")).toBeVisible();
+    await expect(page.getByText("doc-upload-001")).toBeVisible();
+  });
+
   test("indexing failure shows the actual server error instead of a JSON parse error", async ({
     page,
     consoleErrors,
@@ -258,11 +301,14 @@ test.describe("Module 3 — Search Workflow", () => {
     await page.getByRole("button", { name: /Search/ }).click();
 
     const searchRequest = await searchRequestPromise;
-    expect(searchRequest.postDataJSON()).toEqual({
+    const searchPayload = searchRequest.postDataJSON();
+    expect(searchPayload).toEqual({
       query: "service agreement obligations",
       top: 5,
       use_semantic: true,
+      upload_scope: expect.any(String),
     });
+    expect(searchPayload.upload_scope.length).toBeGreaterThan(10);
 
     await expect(page.getByText("🔎 Results — 2 hit(s)")).toBeVisible();
 

--- a/tests/test_ais_router.py
+++ b/tests/test_ais_router.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 
@@ -68,6 +70,88 @@ def test_index_with_custom_fields_reaches_azure(client):  # type: ignore[no-unty
                 ],
             },
         )
+
+
+def test_index_accepts_multipart_upload(client):  # type: ignore[no-untyped-def]
+    """POST /api/search/index accepts uploaded documents as multipart form data."""
+    with pytest.raises(RuntimeError, match="AI_SERVICES_ENDPOINT"):
+        client.post(
+            "/api/search/index",
+            data={
+                "fields": json.dumps(
+                    [{"name": "summary", "type": "string", "description": "A summary"}]
+                ),
+                "upload_scope": "test-scope",
+            },
+            files={"file": ("upload.pdf", b"%PDF-1.4\n", "application/pdf")},
+        )
+
+
+def test_index_multipart_rejects_invalid_fields(client):  # type: ignore[no-untyped-def]
+    resp = client.post(
+        "/api/search/index",
+        data={"fields": "not-json", "upload_scope": "test-scope"},
+        files={"file": ("upload.pdf", b"%PDF-1.4\n", "application/pdf")},
+    )
+    assert resp.status_code == 400
+    assert "valid JSON" in resp.json()["detail"]
+
+
+def test_index_multipart_upload_requires_scope(client):  # type: ignore[no-untyped-def]
+    resp = client.post(
+        "/api/search/index",
+        files={"file": ("upload.pdf", b"%PDF-1.4\n", "application/pdf")},
+    )
+    assert resp.status_code == 400
+    assert "upload_scope" in resp.json()["detail"]
+
+
+def test_uploaded_document_id_uses_content_hash_and_scope() -> None:
+    from workshop.routers.ais import _index_document_source
+    from workshop.routers.documents import DocumentSource
+
+    async def run() -> tuple[str, str]:
+        from unittest.mock import AsyncMock, patch
+
+        async def analyze(_analyzer_id, _content, _filename, _fields):  # type: ignore[no-untyped-def]
+            return {
+                "result": {"fields": {}, "content": "body"},
+                "trace": {"duration_ms": 1, "response": {"status": 200}},
+            }
+
+        with (
+            patch("workshop.routers.ais.cu_service.analyze_custom", AsyncMock(side_effect=analyze)),
+            patch(
+                "workshop.routers.ais.ais_service.index_document",
+                AsyncMock(return_value={"result": {"indexed": 1, "total": 1}, "trace": {}}),
+            ),
+        ):
+            first = await _index_document_source(
+                DocumentSource(
+                    content=b"one",
+                    filename="same.pdf",
+                    id_source="upload:same.pdf:hash-one",
+                    source_type="upload",
+                ),
+                [],
+                "scope-a",
+            )
+            second = await _index_document_source(
+                DocumentSource(
+                    content=b"one",
+                    filename="same.pdf",
+                    id_source="upload:same.pdf:hash-one",
+                    source_type="upload",
+                ),
+                [],
+                "scope-b",
+            )
+        return first["result"]["document_id"], second["result"]["document_id"]
+
+    import asyncio
+
+    first_id, second_id = asyncio.run(run())
+    assert first_id != second_id
 
 
 def test_ensure_index_returns_error_trace(client):  # type: ignore[no-untyped-def]

--- a/tests/test_ais_service.py
+++ b/tests/test_ais_service.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from azure.core.exceptions import HttpResponseError
 
 from workshop.services.ai_search import (
+    _build_visibility_filter,
     build_document_id,
     ensure_index,
     get_index_stats,
@@ -22,13 +23,13 @@ async def test_ensure_index_success(mock_get_client: MagicMock) -> None:
     """Successful index creation returns name + field count."""
     mock_result = MagicMock()
     mock_result.name = "workshop-index"
-    mock_result.fields = [MagicMock()] * 7  # 7 fields in schema
+    mock_result.fields = [MagicMock()] * 9  # 9 fields in schema
     mock_get_client.return_value.create_or_update_index.return_value = mock_result
 
     result = await ensure_index()
 
     assert result["result"]["name"] == "workshop-index"
-    assert result["result"]["fields"] == 7
+    assert result["result"]["fields"] == 9
     assert result["trace"]["response"]["status"] == 200
     assert result["trace"]["duration_ms"] >= 0
 
@@ -159,6 +160,17 @@ async def test_search_documents_success(mock_get_client: MagicMock) -> None:
     assert result["result"]["hits"][0]["key_topics"] == "billing, payment"
     assert result["result"]["hits"][0]["score"] == 0.95
     assert result["result"]["total"] == 1
+    assert (
+        mock_get_client.return_value.search.call_args.kwargs["filter"] == "source_type eq 'sample'"
+    )
+
+
+def test_build_visibility_filter_includes_upload_scope() -> None:
+    assert _build_visibility_filter(None) == "source_type eq 'sample'"
+    assert (
+        _build_visibility_filter("abc'123")
+        == "source_type eq 'sample' or upload_scope eq 'abc''123'"
+    )
 
 
 @patch("workshop.services.ai_search._get_search_client")
@@ -173,6 +185,40 @@ async def test_search_documents_no_count_fallback(mock_get_client: MagicMock) ->
     result = await search_documents("test")
 
     assert result["result"]["total"] == 1  # falls back to len(hits)
+
+
+@patch("workshop.services.ai_search._backfill_sample_source_metadata")
+@patch("workshop.services.ai_search._get_index_client")
+@patch("workshop.services.ai_search._get_search_client")
+async def test_search_documents_ensures_old_index_and_retries(
+    mock_search_client: MagicMock,
+    mock_index_client: MagicMock,
+    mock_backfill: MagicMock,
+) -> None:
+    """Missing filter fields trigger one ensure-index migration and retry."""
+    first_error = HttpResponseError(
+        message="Invalid expression: Could not find a property named 'source_type'"
+    )
+    first_error.status_code = 400
+
+    mock_hit = {"id": "doc1", "title": "Contract", "content": "body"}
+    mock_results = MagicMock()
+    mock_results.__iter__ = MagicMock(return_value=iter([mock_hit]))
+    mock_results.get_count.return_value = 1
+    mock_search_client.return_value.search.side_effect = [first_error, mock_results]
+
+    mock_index_result = MagicMock()
+    mock_index_result.name = "workshop-index"
+    mock_index_result.fields = [MagicMock()] * 9
+    mock_index_client.return_value.create_or_update_index.return_value = mock_index_result
+    mock_backfill.return_value = {"attempted": 1, "updated": 1, "failed": 0}
+
+    result = await search_documents("contract")
+
+    assert result["trace"]["response"]["status"] == 200
+    assert result["trace"]["request"]["body"]["retried_after_ensure_index"] is True
+    assert result["result"]["hits"][0]["title"] == "Contract"
+    assert mock_search_client.return_value.search.call_count == 2
 
 
 @patch("workshop.services.ai_search._get_search_client")

--- a/tests/test_batch_router.py
+++ b/tests/test_batch_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -51,6 +52,61 @@ async def test_batch_deduplicates_samples(client: AsyncClient) -> None:
         )
     assert resp.status_code == 200
     mock_process.assert_called_once_with(["a.pdf"])
+
+
+@pytest.mark.asyncio
+async def test_batch_accepts_mixed_samples_and_uploads(client: AsyncClient) -> None:
+    """Multipart batch requests can include samples plus uploaded files."""
+    mock_process = AsyncMock(
+        return_value={
+            "result": {
+                "documents": [{"sample": "contract.pdf"}, {"sample": "upload.pdf"}],
+                "summary": {"total": 2, "succeeded": 2, "failed": 0},
+            },
+            "trace": {},
+        }
+    )
+    with patch("workshop.routers.batch.batch_service.process_batch_items", mock_process):
+        resp = await client.post(
+            "/api/batch/process",
+            data={"samples": json.dumps(["contract.pdf"]), "upload_scope": "test-scope"},
+            files={"files": ("upload.pdf", b"%PDF-1.4\n", "application/pdf")},
+        )
+
+    assert resp.status_code == 200
+    args = mock_process.call_args.args[0]
+    assert args[0] == "contract.pdf"
+    assert args[1].filename == "upload.pdf"
+    assert args[1].source_type == "upload"
+    assert mock_process.call_args.args[1] == "test-scope"
+
+
+@pytest.mark.asyncio
+async def test_batch_multipart_rejects_oversize_upload(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/api/batch/process",
+        data={"upload_scope": "test-scope"},
+        files={"files": ("large.pdf", b"x" * (10 * 1024 * 1024 + 1), "application/pdf")},
+    )
+    assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_batch_multipart_upload_requires_scope(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/api/batch/process",
+        files={"files": ("upload.pdf", b"%PDF-1.4\n", "application/pdf")},
+    )
+    assert resp.status_code == 400
+    assert "upload_scope" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_batch_multipart_rejects_too_many_uploads(client: AsyncClient) -> None:
+    files = [("files", (f"upload-{i}.pdf", b"%PDF-1.4\n", "application/pdf")) for i in range(21)]
+    resp = await client.post("/api/batch/process", files=files)
+    assert resp.status_code == 400
+    assert "exceeds maximum" in resp.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_cu_router.py
+++ b/tests/test_cu_router.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 
 def test_cu_layout_requires_file_or_sample(client):  # type: ignore[no-untyped-def]
     resp = client.post("/api/cu/layout")
@@ -57,3 +59,30 @@ def test_cu_custom_nonexistent_sample_returns_404(client):  # type: ignore[no-un
     )
     assert resp.status_code == 404
     assert "not found" in resp.json()["detail"].lower()
+
+
+def test_cu_custom_accepts_multipart_upload(client):  # type: ignore[no-untyped-def]
+    """CU custom accepts an uploaded file plus JSON field definitions."""
+    import pytest
+
+    with pytest.raises(RuntimeError, match="AI_SERVICES_ENDPOINT"):
+        client.post(
+            "/api/cu/custom",
+            data={
+                "fields": json.dumps(
+                    [{"name": "summary", "type": "string", "description": "A summary"}]
+                ),
+                "analyzer_id": "workshopUpload",
+            },
+            files={"file": ("upload.pdf", b"%PDF-1.4\n", "application/pdf")},
+        )
+
+
+def test_cu_custom_multipart_rejects_invalid_fields(client):  # type: ignore[no-untyped-def]
+    resp = client.post(
+        "/api/cu/custom",
+        data={"fields": "not-json", "analyzer_id": "workshopUpload"},
+        files={"file": ("upload.pdf", b"%PDF-1.4\n", "application/pdf")},
+    )
+    assert resp.status_code == 400
+    assert "valid JSON" in resp.json()["detail"]

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -33,3 +33,34 @@ def test_get_sample_raw_contract_pdf(client):  # type: ignore[no-untyped-def]
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/pdf"
     assert len(resp.content) > 0
+
+
+def test_upload_document_returns_metadata(client):  # type: ignore[no-untyped-def]
+    resp = client.post(
+        "/api/documents/upload",
+        files={"file": ("upload.pdf", b"%PDF-1.4\n", "application/pdf")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["filename"] == "upload.pdf"
+    assert data["size_bytes"] == 9
+    assert data["content_type"] == "application/pdf"
+    assert data["source_type"] == "upload"
+
+
+def test_upload_document_rejects_unsupported_extension(client):  # type: ignore[no-untyped-def]
+    resp = client.post(
+        "/api/documents/upload",
+        files={"file": ("notes.txt", b"hello", "text/plain")},
+    )
+    assert resp.status_code == 400
+    assert "does not support" in resp.json()["detail"]
+
+
+def test_upload_document_rejects_oversized_file(client):  # type: ignore[no-untyped-def]
+    resp = client.post(
+        "/api/documents/upload",
+        files={"file": ("large.pdf", b"x" * (10 * 1024 * 1024 + 1), "application/pdf")},
+    )
+    assert resp.status_code == 413
+    assert "maximum upload size" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

Restore user document uploads across the workshop so users can analyze,
extract, index, and batch-process their own files alongside bundled samples.

### Changes

- Add shared upload validation, chunked upload reads, filename normalization,
  and deterministic uploaded-document identities.
- Preserve existing sample-based API contracts while adding multipart upload
  paths for CU custom extraction, AI Search indexing, and batch processing.
- Add upload UI and preview/fallback handling in Modules 1-4.
- Disclose when uploaded content is indexed into Azure AI Search.
- Update README and architecture docs with upload limits and persistence notes.
- Add backend and Playwright coverage for uploaded document workflows.

### Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -v` (99 passed)
- `npx playwright test --grep-invert Smoke --project="Desktop Edge"` (33 passed)
- `BASE_URL=<deployed-app> npx playwright test --grep Smoke --project="Desktop Edge"` (10 passed)
