### PR TITLE
feat: Add patient log analyzer

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,13 @@
 # Azure AI Services (Foundry resource with CU + DI support)
 AI_SERVICES_ENDPOINT=https://your-resource.cognitiveservices.azure.com/
-AI_SERVICES_KEY=  # Optional if using managed identity
+# Optional if using managed identity
+AI_SERVICES_KEY=
+# Optional; enables /api/patient-logs/ensure-analyzers when set
+ADMIN_API_KEY=
+CU_COMPLETION_MODEL=gpt-5.2
+CU_COMPLETION_DEPLOYMENT=gpt-5.2
+CU_EMBEDDING_MODEL=text-embedding-3-large
+CU_EMBEDDING_DEPLOYMENT=text-embedding-3-large
 
 # Storage
 STORAGE_ACCOUNT_URL=https://your-storage.blob.core.windows.net/

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -157,22 +157,54 @@ jobs:
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --query id -o tsv)
 
-          if az containerapp show --name idp-workshop --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --query name -o tsv 2>/dev/null; then
+          APP_EXISTS=$(az containerapp show \
+            --name idp-workshop \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --query name -o tsv 2>/dev/null || true)
+
+          ENV_ARGS=(
+            ENVIRONMENT=${{ env.ENVIRONMENT }}
+            AI_SERVICES_ENDPOINT=${{ steps.runtime.outputs.ai_services_endpoint }}
+            STORAGE_ACCOUNT_URL=${{ steps.runtime.outputs.storage_account_url }}
+            LOG_LEVEL=INFO
+            AZURE_CLIENT_ID=${{ steps.runtime.outputs.azure_client_id }}
+            CU_COMPLETION_MODEL=gpt-5.2
+            CU_COMPLETION_DEPLOYMENT=gpt-5.2
+            CU_EMBEDDING_MODEL=text-embedding-3-large
+            CU_EMBEDDING_DEPLOYMENT=text-embedding-3-large
+            AIS_ENDPOINT=${{ steps.runtime.outputs.ais_endpoint }}
+            AIS_INDEX_NAME=workshop-documents
+          )
+          SECRET_ARGS=()
+          if [ -n "$PATIENT_LOG_ADMIN_API_KEY" ]; then
+            if [ -n "$APP_EXISTS" ]; then
+              az containerapp secret set \
+                --name idp-workshop \
+                --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+                --secrets "patient-log-admin-api-key=$PATIENT_LOG_ADMIN_API_KEY" \
+                --output none
+            else
+              SECRET_ARGS=(--secrets "patient-log-admin-api-key=$PATIENT_LOG_ADMIN_API_KEY")
+            fi
+            ENV_ARGS+=(ADMIN_API_KEY=secretref:patient-log-admin-api-key)
+          else
+            if [ -n "$APP_EXISTS" ]; then
+              az containerapp secret remove \
+                --name idp-workshop \
+                --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+                --secret-names patient-log-admin-api-key \
+                --output none 2>/dev/null || true
+            fi
+            ENV_ARGS+=(ADMIN_API_KEY=)
+          fi
+
+          if [ -n "$APP_EXISTS" ]; then
             echo "Container app exists — updating"
             az containerapp update \
               --name idp-workshop \
               --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
               --image ${{ steps.image.outputs.image-ref }} \
-              --set-env-vars \
-                ENVIRONMENT=${{ env.ENVIRONMENT }} \
-                AI_SERVICES_ENDPOINT=${{ steps.runtime.outputs.ai_services_endpoint }} \
-                STORAGE_ACCOUNT_URL=${{ steps.runtime.outputs.storage_account_url }} \
-                LOG_LEVEL=INFO \
-                AZURE_CLIENT_ID=${{ steps.runtime.outputs.azure_client_id }} \
-                CU_COMPLETION_DEPLOYMENT=gpt-4.1 \
-                CU_EMBEDDING_DEPLOYMENT=text-embedding-3-large \
-                AIS_ENDPOINT=${{ steps.runtime.outputs.ais_endpoint }} \
-                AIS_INDEX_NAME=workshop-documents \
+              --set-env-vars "${ENV_ARGS[@]}" \
               --output none
           else
             echo "Container app does not exist — creating"
@@ -187,16 +219,8 @@ jobs:
               --ingress external --target-port 8080 \
               --revisions-mode multiple \
               --min-replicas 1 --max-replicas 3 \
-              --env-vars \
-                ENVIRONMENT=${{ env.ENVIRONMENT }} \
-                AI_SERVICES_ENDPOINT=${{ steps.runtime.outputs.ai_services_endpoint }} \
-                STORAGE_ACCOUNT_URL=${{ steps.runtime.outputs.storage_account_url }} \
-                LOG_LEVEL=INFO \
-                AZURE_CLIENT_ID=${{ steps.runtime.outputs.azure_client_id }} \
-                CU_COMPLETION_DEPLOYMENT=gpt-4.1 \
-                CU_EMBEDDING_DEPLOYMENT=text-embedding-3-large \
-                AIS_ENDPOINT=${{ steps.runtime.outputs.ais_endpoint }} \
-                AIS_INDEX_NAME=workshop-documents \
+              "${SECRET_ARGS[@]}" \
+              --env-vars "${ENV_ARGS[@]}" \
               --output none
           fi
 
@@ -205,6 +229,8 @@ jobs:
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --query "properties.configuration.ingress.fqdn" -o tsv)
           echo "app_url=https://${APP_URL}" >> "$GITHUB_OUTPUT"
+        env:
+          PATIENT_LOG_ADMIN_API_KEY: ${{ secrets.PATIENT_LOG_ADMIN_API_KEY }}
 
       - name: Route traffic to latest revision
         run: |

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -1,7 +1,8 @@
 name: PR Staging
 
 on:
-  workflow_dispatch:
+  pull_request:
+    types: [closed]
 
 permissions:
   id-token: write
@@ -9,7 +10,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pr-staging-${{ github.event.pull_request.number }}
+  group: pr-staging-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -27,15 +28,49 @@ env:
 jobs:
   deploy:
     name: Deploy Preview
-    if: >-
-      github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.actor != 'dependabot[bot]'
+    # Disabled until preview deploys use isolated, least-privilege resources.
+    if: false
     runs-on: ubuntu-latest
+    environment: pr-preview
     outputs:
       preview_url: ${{ steps.review.outputs.preview_url }}
+      head_sha: ${{ steps.preview.outputs.head_sha }}
     steps:
+      - name: Validate preview inputs
+        id: preview
+        shell: bash
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "pr_number must contain digits only"
+            exit 1
+          fi
+          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json number,state,isCrossRepository,headRefOid)
+          CANONICAL_PR_NUMBER=$(jq -r '.number' <<< "$PR_JSON")
+          PR_STATE=$(jq -r '.state' <<< "$PR_JSON")
+          IS_CROSS_REPOSITORY=$(jq -r '.isCrossRepository' <<< "$PR_JSON")
+          HEAD_SHA=$(jq -r '.headRefOid' <<< "$PR_JSON")
+          if [ "$PR_STATE" != "OPEN" ]; then
+            echo "Preview deploys are only allowed for open pull requests"
+            exit 1
+          fi
+          if [ "$IS_CROSS_REPOSITORY" != "false" ]; then
+            echo "Preview deploys are restricted to same-repository pull requests"
+            exit 1
+          fi
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve a valid pull request head SHA"
+            exit 1
+          fi
+          echo "pr_number=$CANONICAL_PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.preview.outputs.head_sha }}
+          persist-credentials: false
 
       - name: Azure Login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
@@ -137,9 +172,9 @@ jobs:
       - name: Set image tag
         id: vars
         run: |
-          SHORT_SHA=${GITHUB_SHA:0:7}
+          SHORT_SHA=$(git rev-parse --short HEAD)
           echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
-          echo "image_ref=${{ env.ACR_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "image_ref=${{ env.ACR_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:pr-${{ steps.preview.outputs.pr_number }}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: ACR Login
         run: az acr login --name ${{ env.ACR_NAME }}
@@ -155,7 +190,7 @@ jobs:
           REVISIONS=$(az containerapp revision list \
             --name ${{ env.CONTAINERAPP_NAME }} \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --query "[?contains(name, '--pr-${{ github.event.pull_request.number }}')].name" -o tsv)
+            --query "[?contains(name, '--pr-${{ steps.preview.outputs.pr_number }}-')].name" -o tsv)
           for REV in $REVISIONS; do
             echo "Deactivating old revision: $REV"
             az containerapp revision deactivate \
@@ -167,9 +202,9 @@ jobs:
       - name: Deploy preview revision
         id: review
         run: |
-          PR_NUM=${{ github.event.pull_request.number }}
+          PR_NUM=${{ steps.preview.outputs.pr_number }}
           SHORT_SHA=${{ steps.vars.outputs.short_sha }}
-          REVISION_SUFFIX="pr-${PR_NUM}-${SHORT_SHA}"
+          REVISION_SUFFIX="pr-${PR_NUM}-${SHORT_SHA}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
 
           # Capture the current production revision before creating the PR revision
           PROD_REVISION=$(az containerapp ingress traffic show \
@@ -184,21 +219,27 @@ jobs:
           fi
           echo "Production revision: $PROD_REVISION"
 
+          ENV_ARGS=(
+            ENVIRONMENT=${{ env.ENVIRONMENT }}
+            AI_SERVICES_ENDPOINT=${{ steps.runtime.outputs.ai_services_endpoint }}
+            STORAGE_ACCOUNT_URL=${{ steps.runtime.outputs.storage_account_url }}
+            LOG_LEVEL=INFO
+            AZURE_CLIENT_ID=${{ steps.runtime.outputs.azure_client_id }}
+            CU_COMPLETION_MODEL=gpt-5.2
+            CU_COMPLETION_DEPLOYMENT=gpt-5.2
+            CU_EMBEDDING_MODEL=text-embedding-3-large
+            CU_EMBEDDING_DEPLOYMENT=text-embedding-3-large
+            AIS_ENDPOINT=${{ steps.runtime.outputs.ais_endpoint }}
+            AIS_INDEX_NAME=workshop-documents-pr-${PR_NUM}
+          )
+          ENV_ARGS+=(ADMIN_API_KEY=)
+
           az containerapp update \
             --name ${{ env.CONTAINERAPP_NAME }} \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --image ${{ steps.vars.outputs.image_ref }} \
             --revision-suffix "$REVISION_SUFFIX" \
-            --set-env-vars \
-              ENVIRONMENT=${{ env.ENVIRONMENT }} \
-              AI_SERVICES_ENDPOINT=${{ steps.runtime.outputs.ai_services_endpoint }} \
-              STORAGE_ACCOUNT_URL=${{ steps.runtime.outputs.storage_account_url }} \
-              LOG_LEVEL=INFO \
-              AZURE_CLIENT_ID=${{ steps.runtime.outputs.azure_client_id }} \
-              CU_COMPLETION_DEPLOYMENT=gpt-4.1 \
-              CU_EMBEDDING_DEPLOYMENT=text-embedding-3-large \
-              AIS_ENDPOINT=${{ steps.runtime.outputs.ais_endpoint }} \
-              AIS_INDEX_NAME=workshop-documents-pr-${PR_NUM} \
+            --set-env-vars "${ENV_ARGS[@]}" \
             --output none
 
           # Ensure production revision keeps 100% traffic
@@ -228,7 +269,6 @@ jobs:
 
           echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
           echo "Preview URL: $PREVIEW_URL"
-
       - name: Wait for revision health
         run: |
           PREVIEW_URL="${{ steps.review.outputs.preview_url }}"
@@ -248,7 +288,7 @@ jobs:
         with:
           script: |
             const url = '${{ steps.review.outputs.preview_url }}';
-            const sha = '${{ github.sha }}'.substring(0, 7);
+            const sha = '${{ steps.preview.outputs.head_sha }}'.substring(0, 7);
             const marker = '## 🚀 PR Preview';
             const body = [
               marker,
@@ -264,7 +304,7 @@ jobs:
             ].join('\n');
 
             const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
+            const issue_number = Number('${{ steps.preview.outputs.pr_number }}');
             const comments = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
             const existing = comments.data.find(c => c.user?.type === 'Bot' && c.body?.includes(marker));
 
@@ -279,15 +319,20 @@ jobs:
           echo "## 🚀 PR Preview Deployed" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**URL:** ${{ steps.review.outputs.preview_url }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Commit:** \`${GITHUB_SHA:0:7}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Commit:** \`${{ steps.preview.outputs.head_sha }}\`" >> "$GITHUB_STEP_SUMMARY"
 
   e2e:
     name: E2E Tests (Preview)
     needs: deploy
     if: needs.deploy.outputs.preview_url != ''
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.deploy.outputs.head_sha }}
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -331,7 +376,7 @@ jobs:
           REVISIONS=$(az containerapp revision list \
             --name ${{ env.CONTAINERAPP_NAME }} \
             --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-            --query "[?contains(name, '--pr-${{ github.event.pull_request.number }}')].name" -o tsv)
+            --query "[?contains(name, '--pr-${{ github.event.pull_request.number }}-')].name" -o tsv)
           for REV in $REVISIONS; do
             echo "Deactivating revision: $REV"
             az containerapp revision deactivate \
@@ -339,6 +384,11 @@ jobs:
               --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
               --revision "$REV" || true
           done
+          az containerapp secret remove \
+            --name ${{ env.CONTAINERAPP_NAME }} \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --secret-names patient-log-admin-api-key-pr-${{ github.event.pull_request.number }} \
+            --output none 2>/dev/null || true
 
       - name: Delete PR search index
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,9 @@ class Settings(BaseSettings):
     azure_client_id: str = ""           # Managed identity client ID (prod only)
     environment: str = "dev"            # Environment name (dev, stage, prod)
     log_level: str = "INFO"             # Python log level
-    cu_completion_deployment: str = "gpt-4.1"
+    cu_completion_model: str = "gpt-5.2"
+    cu_completion_deployment: str = "gpt-5.2"
+    cu_embedding_model: str = "text-embedding-3-large"
     cu_embedding_deployment: str = "text-embedding-3-large"
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.12-slim AS base
 
 WORKDIR /app
 
+# Patch OS-level vulnerabilities
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.7.12 /uv /usr/local/bin/uv
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -385,11 +385,14 @@ export const consoleErrorHandler = test.extend({
 |----------|----------|---------|-------------|
 | `AI_SERVICES_ENDPOINT` | Yes | `""` | Azure AI Services endpoint URL |
 | `AI_SERVICES_KEY` | No | `""` | API key (if empty, uses managed identity) |
+| `ADMIN_API_KEY` | No | `""` | Enables admin-only analyzer creation endpoints |
 | `STORAGE_ACCOUNT_URL` | No | `""` | Azure Blob Storage endpoint |
 | `AZURE_CLIENT_ID` | Yes (prod) | — | Managed identity client ID |
 | `ENVIRONMENT` | No | `"dev"` | Environment (dev/stage/prod) |
 | `LOG_LEVEL` | No | `"INFO"` | Python log level (DEBUG/INFO/WARNING/ERROR) |
-| `CU_COMPLETION_DEPLOYMENT` | No | `"gpt-4.1"` | CU GPT-4 deployment name |
+| `CU_COMPLETION_MODEL` | No | `"gpt-5.2"` | CU completion model name |
+| `CU_COMPLETION_DEPLOYMENT` | No | `"gpt-5.2"` | CU completion deployment name |
+| `CU_EMBEDDING_MODEL` | No | `"text-embedding-3-large"` | CU embedding model name |
 | `CU_EMBEDDING_DEPLOYMENT` | No | `"text-embedding-3-large"` | CU embedding deployment name |
 
 ### Loading
@@ -416,11 +419,14 @@ Settings loaded via Pydantic in `src/workshop/config.py`:
 class Settings(BaseSettings):
     ai_services_endpoint: str
     ai_services_key: str = ""
+    admin_api_key: str = ""
     storage_account_url: str = ""
     azure_client_id: str = ""
     environment: str = "dev"
     log_level: str = "INFO"
-    cu_completion_deployment: str = "gpt-4.1"
+    cu_completion_model: str = "gpt-5.2"
+    cu_completion_deployment: str = "gpt-5.2"
+    cu_embedding_model: str = "text-embedding-3-large"
     cu_embedding_deployment: str = "text-embedding-3-large"
 
     class Config:

--- a/docs/patient-log-analyzer.md
+++ b/docs/patient-log-analyzer.md
@@ -1,0 +1,115 @@
+# Patient Log Analyzer
+
+This is a low-visibility scenario demo for a Content Understanding-only patient
+treatment log analyzer. It is intentionally not listed as a numbered workshop
+module. Open it directly at:
+
+```text
+/patient-log
+```
+
+## Goal
+
+Show how Azure AI Content Understanding can:
+
+- segment a scanned patient-log packet into document sections;
+- route patient-log/body-diagram sections to a treatment-log analyzer;
+- reason over visual marks on body diagrams and spinal palpation sections;
+- return structured findings, missing-information notes, and ambiguity notes;
+- export derived JSON to the browser without server-side storage.
+
+This demo does not use Document Intelligence. The output is semantic evidence,
+not coordinate-perfect layout evidence. Use DI plus CU later if production
+workflows require exact bounding regions, table geometry, or audit coordinates.
+
+## Azure resources
+
+Reuse the existing Azure AI Services / Foundry resource from the IDP workshop.
+Do not create a new Foundry resource for this demo.
+
+Required app settings:
+
+```text
+AI_SERVICES_ENDPOINT=<existing idp-workshop-ai endpoint>
+AI_SERVICES_KEY=<optional, if not using managed identity>
+ADMIN_API_KEY=<required to create/update analyzers from the web app>
+CU_COMPLETION_MODEL=gpt-5.2
+CU_COMPLETION_DEPLOYMENT=gpt-5.2
+CU_EMBEDDING_MODEL=text-embedding-3-large
+CU_EMBEDDING_DEPLOYMENT=text-embedding-3-large
+```
+
+Keep `gpt-4.1` deployed as a fallback while validating `gpt-5.2`. The app
+uses `gpt-5.2` by default for new patient-log analyzers.
+
+The analyzer IDs are intentionally short and document-type based:
+
+- `patient_log_classifier`
+- `patient_log_treatment`
+
+The analyzer setup endpoint is protected by `ADMIN_API_KEY` because it creates
+or replaces analyzer resources using the app's Azure identity. Leave
+`ADMIN_API_KEY` unset to disable analyzer mutation in a public deployment, or
+configure it as a Container Apps secret when analyzer setup should be available.
+
+## Foundry project and model IaC
+
+The runtime app calls resource-level Content Understanding analyzer endpoints on
+the existing `idp-workshop-ai` resource. However, the portal experience can
+require a Foundry project for authoring and model deployment workflows. The
+deployment templates therefore also create a project under the same resource:
+
+```text
+foundryProjectName=patient-log-demo
+foundryProjectDisplayName=Patient Log Demo
+```
+
+This project is for portal/model-authoring UX. It does not replace the
+resource-level API endpoint used by the app, and it does not require a separate
+Foundry resource.
+
+The IaC deploys `gpt-5.2` as the default CU completion model and keeps
+`gpt-4.1` as a fallback while the newer model is validated. If `gpt-5.2` is not
+available in the subscription/region, switch `CU_COMPLETION_MODEL` and
+`CU_COMPLETION_DEPLOYMENT` back to the fallback deployment.
+
+## Content Understanding Studio demo
+
+Use Content Understanding Studio when you want to demonstrate visual authoring
+inside the Azure portal experience.
+
+1. Open Content Understanding Studio.
+2. Create a project using **Classify and route with custom categories**.
+3. Select the existing `idp-workshop-ai` Foundry/Azure AI Services resource.
+4. Use an external/manual sample from OneDrive. Do not upload or commit real
+   patient/customer samples into this repository.
+5. Create categories matching the app definitions:
+   - `patient_treatment_log`
+   - `palpation_body_diagram`
+   - `claim_or_cover_sheet`
+   - `invoice_or_billing`
+   - `correspondence`
+   - `other`
+6. Build a treatment-log analyzer with fields for visit entries, body diagram
+   findings, spinal palpation findings, missing entries, ambiguity notes, and
+   an overall summary.
+7. Route `patient_treatment_log` and `palpation_body_diagram` categories to the
+   treatment-log analyzer.
+8. Test against the external sample packet.
+
+The `/patient-log` page exposes the JSON analyzer definitions used by the app so
+you can compare the portal project configuration with the direct API version.
+
+## Privacy and persistence
+
+- Real patient/customer samples stay external and manual-only.
+- The app processes uploads request-by-request.
+- Raw uploads are not stored by the app.
+- Patient-log outputs are not indexed into Azure AI Search.
+- The only persistence path is explicit browser-side JSON export/download.
+
+## Testing strategy
+
+Repository tests use mocked API responses and synthetic fixture data only. Live
+smoke tests should verify that the page loads and controls render, not that real
+patient documents are analyzed.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -38,6 +38,30 @@ param logAnalyticsWorkspaceName string = 'idp-workshop-logs'
 @description('AI Search service name (globally unique)')
 param aiSearchName string = 'idp-workshop-search'
 
+@description('CU completion model name')
+param cuCompletionModelName string = 'gpt-5.2'
+
+@description('CU completion deployment name')
+param cuCompletionDeploymentName string = 'gpt-5.2'
+
+@description('CU completion model version')
+param cuCompletionModelVersion string = '2025-12-11'
+
+@description('CU embedding model name')
+param cuEmbeddingModelName string = 'text-embedding-3-large'
+
+@description('CU embedding deployment name')
+param cuEmbeddingDeploymentName string = 'text-embedding-3-large'
+
+@description('Deploy GPT-4.1 as a fallback CU completion model')
+param deployGpt41Fallback bool = true
+
+@description('Foundry project name for portal authoring and model deployment UX. Set empty to skip project creation.')
+param foundryProjectName string = ''
+
+@description('Foundry project display name')
+param foundryProjectDisplayName string = 'Patient Log Demo'
+
 param tags object = {}
 
 // ── Computed Names ──────────────────────────────────────────────────────────
@@ -54,6 +78,14 @@ module aiServices 'modules/ai-services.bicep' = {
   params: {
     name: aiServicesName
     location: location
+    cuCompletionModelName: cuCompletionModelName
+    cuCompletionDeploymentName: cuCompletionDeploymentName
+    cuCompletionModelVersion: cuCompletionModelVersion
+    cuEmbeddingModelName: cuEmbeddingModelName
+    cuEmbeddingDeploymentName: cuEmbeddingDeploymentName
+    deployGpt41Fallback: deployGpt41Fallback
+    foundryProjectName: foundryProjectName
+    foundryProjectDisplayName: foundryProjectDisplayName
     tags: tags
   }
 }
@@ -149,8 +181,10 @@ module app 'modules/container-app.bicep' = if (!empty(containerImage)) {
       { name: 'STORAGE_ACCOUNT_URL', value: storage.outputs.blobEndpoint }
       { name: 'LOG_LEVEL', value: environmentName == 'prod' ? 'INFO' : 'DEBUG' }
       { name: 'AZURE_CLIENT_ID', value: identity.properties.clientId }
-      { name: 'CU_COMPLETION_DEPLOYMENT', value: 'gpt-4.1' }
-      { name: 'CU_EMBEDDING_DEPLOYMENT', value: 'text-embedding-3-large' }
+      { name: 'CU_COMPLETION_MODEL', value: cuCompletionModelName }
+      { name: 'CU_COMPLETION_DEPLOYMENT', value: cuCompletionDeploymentName }
+      { name: 'CU_EMBEDDING_MODEL', value: cuEmbeddingModelName }
+      { name: 'CU_EMBEDDING_DEPLOYMENT', value: cuEmbeddingDeploymentName }
       { name: 'AIS_ENDPOINT', value: aiSearch.outputs.endpoint }
       { name: 'AIS_INDEX_NAME', value: 'workshop-documents' }
     ]
@@ -162,5 +196,7 @@ module app 'modules/container-app.bicep' = if (!empty(containerImage)) {
 output acrLoginServer string = acr.outputs.acrLoginServer
 output identityPrincipalId string = identity.properties.principalId
 output identityName string = identity.name
+output foundryProjectName string = aiServices.outputs.projectName
+output foundryProjectId string = aiServices.outputs.projectId
 output appUrl string = !empty(containerImage) ? app.outputs.appUrl : ''
 output appFqdn string = !empty(containerImage) ? app.outputs.appFqdn : ''

--- a/infra/modules/ai-services.bicep
+++ b/infra/modules/ai-services.bicep
@@ -9,7 +9,37 @@ param location string = resourceGroup().location
 
 param tags object = {}
 
-resource aiServices 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+@description('Default CU completion model name')
+param cuCompletionModelName string = 'gpt-5.2'
+
+@description('Default CU completion deployment name')
+param cuCompletionDeploymentName string = 'gpt-5.2'
+
+@description('Default CU completion model version')
+param cuCompletionModelVersion string = '2025-12-11'
+
+@description('CU completion deployment SKU')
+param cuCompletionDeploymentSkuName string = 'GlobalStandard'
+
+@description('CU completion deployment capacity')
+param cuCompletionDeploymentCapacity int = 10
+
+@description('Deploy GPT-4.1 as a fallback completion model')
+param deployGpt41Fallback bool = true
+
+@description('CU embedding model name')
+param cuEmbeddingModelName string = 'text-embedding-3-large'
+
+@description('CU embedding deployment name')
+param cuEmbeddingDeploymentName string = 'text-embedding-3-large'
+
+@description('Foundry project name for portal authoring and model deployment UX. Set empty to skip project creation.')
+param foundryProjectName string = ''
+
+@description('Foundry project display name')
+param foundryProjectDisplayName string = 'Patient Log Demo'
+
+resource aiServices 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
   name: name
   location: location
   tags: tags
@@ -18,13 +48,31 @@ resource aiServices 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
     name: 'S0'
   }
   properties: {
+    allowProjectManagement: true
     customSubDomainName: name
     publicNetworkAccess: 'Enabled'
   }
 }
 
-// GPT-4.1 deployment (required for CU custom analyzers)
-resource gpt41 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+// Default completion deployment for CU custom analyzers
+resource completion 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+  parent: aiServices
+  name: cuCompletionDeploymentName
+  sku: {
+    name: cuCompletionDeploymentSkuName
+    capacity: cuCompletionDeploymentCapacity
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: cuCompletionModelName
+      version: cuCompletionModelVersion
+    }
+  }
+}
+
+// GPT-4.1 fallback while validating newer CU completion models
+resource gpt41Fallback 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = if (deployGpt41Fallback && cuCompletionDeploymentName != 'gpt-4.1') {
   parent: aiServices
   name: 'gpt-4.1'
   sku: {
@@ -43,8 +91,8 @@ resource gpt41 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
 // Text embedding deployment (required for CU)
 resource embedding 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
   parent: aiServices
-  name: 'text-embedding-3-large'
-  dependsOn: [gpt41]
+  name: cuEmbeddingDeploymentName
+  dependsOn: [completion]
   sku: {
     name: 'Standard'
     capacity: 10
@@ -52,11 +100,24 @@ resource embedding 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01'
   properties: {
     model: {
       format: 'OpenAI'
-      name: 'text-embedding-3-large'
+      name: cuEmbeddingModelName
       version: '1'
     }
   }
 }
 
+resource foundryProject 'Microsoft.CognitiveServices/accounts/projects@2025-06-01' = if (!empty(foundryProjectName)) {
+  parent: aiServices
+  name: foundryProjectName
+  location: location
+  tags: tags
+  properties: {
+    description: 'Patient treatment log Content Understanding demo project'
+    displayName: foundryProjectDisplayName
+  }
+}
+
 output endpoint string = aiServices.properties.endpoint
 output name string = aiServices.name
+output projectName string = foundryProjectName
+output projectId string = !empty(foundryProjectName) ? foundryProject.id : ''

--- a/src/workshop/config.py
+++ b/src/workshop/config.py
@@ -13,8 +13,13 @@ class Settings(BaseSettings):
     # Azure Storage
     storage_account_url: str = ""
 
-    # CU model deployment names (must match Bicep deployment resource names)
-    cu_completion_deployment: str = "gpt-4.1"
+    # Optional admin token for analyzer create/update operations
+    admin_api_key: str = ""
+
+    # CU model names and deployment names (deployment names must match Azure resources)
+    cu_completion_model: str = "gpt-5.2"
+    cu_completion_deployment: str = "gpt-5.2"
+    cu_embedding_model: str = "text-embedding-3-large"
     cu_embedding_deployment: str = "text-embedding-3-large"
 
     # Azure AI Search

--- a/src/workshop/routers/cu.py
+++ b/src/workshop/routers/cu.py
@@ -10,8 +10,13 @@ from pydantic import BaseModel, ValidationError
 
 from workshop.routers.documents import get_document_source, get_file_bytes
 from workshop.services import content_understanding as cu_service
+from workshop.services.patient_log_analyzers import (
+    PATIENT_LOG_CLASSIFIER_ID,
+    PATIENT_LOG_TREATMENT_ID,
+)
 
 router = APIRouter(prefix="/api/cu", tags=["content-understanding"])
+RESERVED_ANALYZER_IDS = {PATIENT_LOG_CLASSIFIER_ID, PATIENT_LOG_TREATMENT_ID}
 
 
 class CustomField(BaseModel):
@@ -60,6 +65,7 @@ async def cu_custom(
     content_type = request.headers.get("content-type", "")
     if content_type.startswith("application/json"):
         body = await _read_custom_json(request)
+        _reject_reserved_analyzer_id(body.analyzer_id)
         document = await get_document_source(sample=body.sample)
         field_values = [f.model_dump() for f in body.fields] if body.fields else None
         return await cu_service.analyze_custom(
@@ -68,8 +74,10 @@ async def cu_custom(
 
     document = await get_document_source(file=file, sample=sample)
     parsed_fields = _parse_custom_fields(fields)
+    resolved_analyzer_id = analyzer_id or "workshop-custom"
+    _reject_reserved_analyzer_id(resolved_analyzer_id)
     return await cu_service.analyze_custom(
-        analyzer_id or "workshop-custom",
+        resolved_analyzer_id,
         document.content,
         document.filename,
         parsed_fields,
@@ -100,3 +108,11 @@ def _parse_custom_fields(fields: str | None) -> list[dict[str, Any]] | None:
     except (TypeError, ValidationError) as err:
         raise HTTPException(status_code=422, detail="Field definitions are invalid") from err
     return parsed
+
+
+def _reject_reserved_analyzer_id(analyzer_id: str) -> None:
+    if analyzer_id in RESERVED_ANALYZER_IDS:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Analyzer '{analyzer_id}' is reserved for the patient log demo.",
+        )

--- a/src/workshop/routers/patient_logs.py
+++ b/src/workshop/routers/patient_logs.py
@@ -1,0 +1,105 @@
+"""CU-only patient treatment log analyzer endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, File, Header, HTTPException, UploadFile
+
+from workshop.config import settings
+from workshop.routers.documents import get_document_source
+from workshop.services import content_understanding as cu_service
+from workshop.services.patient_log_analyzers import (
+    PATIENT_LOG_CLASSIFIER_ID,
+    PATIENT_LOG_TREATMENT_ID,
+    get_patient_log_analyzer_definitions,
+)
+
+router = APIRouter(prefix="/api/patient-logs", tags=["patient-logs"])
+
+
+@router.get("/analyzer-definitions")
+def analyzer_definitions() -> dict[str, Any]:
+    """Return the analyzer definitions used by the patient log demo."""
+    definitions = _definitions()
+    return {
+        "result": {
+            "classifier_analyzer_id": PATIENT_LOG_CLASSIFIER_ID,
+            "treatment_analyzer_id": PATIENT_LOG_TREATMENT_ID,
+            "definitions": definitions,
+        }
+    }
+
+
+@router.post("/ensure-analyzers")
+async def ensure_analyzers(x_admin_key: Annotated[str | None, Header()] = None) -> dict[str, Any]:
+    """Create or update the patient log analyzers in Content Understanding."""
+    _require_admin(x_admin_key)
+    definitions = _definitions()
+    treatment = await cu_service.create_or_replace_analyzer(
+        PATIENT_LOG_TREATMENT_ID, definitions[PATIENT_LOG_TREATMENT_ID]
+    )
+    classifier = await cu_service.create_or_replace_analyzer(
+        PATIENT_LOG_CLASSIFIER_ID, definitions[PATIENT_LOG_CLASSIFIER_ID]
+    )
+    has_error = bool(
+        treatment.get("trace", {}).get("error") or classifier.get("trace", {}).get("error")
+    )
+    return {
+        "result": {
+            "ready": not has_error,
+            "analyzers": [
+                {
+                    "id": PATIENT_LOG_TREATMENT_ID,
+                    "kind": "treatment-log extractor",
+                    "status": "error" if treatment.get("trace", {}).get("error") else "ready",
+                },
+                {
+                    "id": PATIENT_LOG_CLASSIFIER_ID,
+                    "kind": "classifier/segmenter-router",
+                    "status": "error" if classifier.get("trace", {}).get("error") else "ready",
+                },
+            ],
+        },
+        "trace": {
+            PATIENT_LOG_TREATMENT_ID: treatment.get("trace", {}),
+            PATIENT_LOG_CLASSIFIER_ID: classifier.get("trace", {}),
+        },
+    }
+
+
+@router.post("/analyze")
+async def analyze_patient_log(file: Annotated[UploadFile, File()]) -> dict[str, Any]:
+    """Analyze an uploaded patient treatment log packet without storing it."""
+    document = await get_document_source(file=file)
+    result = await cu_service.analyze_binary_with_analyzer(
+        PATIENT_LOG_CLASSIFIER_ID,
+        document.content,
+        document.filename,
+        document.content_type or "application/octet-stream",
+    )
+    return {
+        "result": {
+            "filename": document.filename,
+            "analyzer_id": PATIENT_LOG_CLASSIFIER_ID,
+            "analysis": result.get("result", {}),
+        },
+        "trace": result.get("trace", {}),
+    }
+
+
+def _definitions() -> dict[str, dict[str, Any]]:
+    return get_patient_log_analyzer_definitions(
+        completion_model=settings.cu_completion_model,
+        embedding_model=settings.cu_embedding_model,
+    )
+
+
+def _require_admin(admin_key: str | None) -> None:
+    if not settings.admin_api_key:
+        raise HTTPException(
+            status_code=403,
+            detail="Analyzer creation is disabled until ADMIN_API_KEY is configured.",
+        )
+    if admin_key != settings.admin_api_key:
+        raise HTTPException(status_code=403, detail="Invalid admin key.")

--- a/src/workshop/server.py
+++ b/src/workshop/server.py
@@ -11,7 +11,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from workshop.config import settings
-from workshop.routers import ais, batch, cu, di, documents, health
+from workshop.routers import ais, batch, cu, di, documents, health, patient_logs
 
 # Logging
 logging.basicConfig(level=getattr(logging, settings.log_level.upper(), logging.INFO))
@@ -41,6 +41,7 @@ app.include_router(di.router)
 app.include_router(cu.router)
 app.include_router(ais.router)
 app.include_router(batch.router)
+app.include_router(patient_logs.router)
 
 
 # ── Page routes ──────────────────────────────────────────────────────────────
@@ -74,3 +75,8 @@ async def module_4(request: Request) -> HTMLResponse:
 @app.get("/guide", response_class=HTMLResponse)
 async def decision_guide(request: Request) -> HTMLResponse:
     return templates.TemplateResponse(request, "guide.html")
+
+
+@app.get("/patient-log", response_class=HTMLResponse)
+async def patient_log_analyzer(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse(request, "patient_log.html")

--- a/src/workshop/services/content_understanding.py
+++ b/src/workshop/services/content_understanding.py
@@ -53,7 +53,10 @@ async def analyze_prebuilt(model_id: str, file_bytes: bytes, filename: str) -> d
 
 
 async def analyze_custom(
-    analyzer_id: str, file_bytes: bytes, filename: str, fields: list[dict[str, str]] | None = None
+    analyzer_id: str,
+    file_bytes: bytes,
+    filename: str,
+    fields: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     """Run a CU custom analyzer with optional field definitions. Returns result + API trace."""
     client = _get_client()
@@ -84,6 +87,91 @@ async def analyze_custom(
             trace.response_status = 200
             result_dict = _result_to_dict(result)
             trace.response_body = result_dict
+        except HttpResponseError as e:
+            trace.error = f"HttpResponseError: {e}"
+            trace.response_status = e.status_code or 500
+            result_dict = {}
+        except Exception as e:
+            trace.error = f"{type(e).__name__}: {e}"
+            trace.response_status = 500
+            result_dict = {}
+
+    trace.duration_ms = timer.duration_ms
+    return {"result": result_dict, "trace": trace.to_dict()}
+
+
+async def create_or_replace_analyzer(
+    analyzer_id: str, definition: dict[str, Any]
+) -> dict[str, Any]:
+    """Create or replace a Content Understanding analyzer from a full definition."""
+    client = _get_client()
+    trace = ApiTrace(service="CU", operation=f"create-analyzer/{analyzer_id}")
+    trace.request_url = (
+        f"{settings.ai_services_endpoint}contentunderstanding/analyzers/{analyzer_id}"
+    )
+    trace.request_method = "PUT"
+    trace.request_headers = sanitize_headers({"Content-Type": "application/json"})
+    trace.request_body = definition
+
+    with TraceTimer() as timer:
+        try:
+            _ensure_defaults(client)
+
+            def _create() -> Any:
+                poller = client.begin_create_analyzer(
+                    analyzer_id=analyzer_id, resource=definition, allow_replace=True
+                )
+                return poller.result()
+
+            result = await asyncio.to_thread(_create)
+            trace.response_status = 200
+            result_dict = _result_to_dict(result)
+            trace.response_body = {"analyzer_id": analyzer_id, "status": "ready"}
+        except HttpResponseError as e:
+            trace.error = f"HttpResponseError: {e}"
+            trace.response_status = e.status_code or 500
+            result_dict = {}
+        except Exception as e:
+            trace.error = f"{type(e).__name__}: {e}"
+            trace.response_status = 500
+            result_dict = {}
+
+    trace.duration_ms = timer.duration_ms
+    return {"result": result_dict, "trace": trace.to_dict()}
+
+
+async def analyze_binary_with_analyzer(
+    analyzer_id: str,
+    file_bytes: bytes,
+    filename: str,
+    content_type: str = "application/octet-stream",
+) -> dict[str, Any]:
+    """Analyze binary input using an existing analyzer ID."""
+    client = _get_client()
+    trace = ApiTrace(service="CU", operation=f"analyze/{analyzer_id}")
+    trace.request_url = (
+        f"{settings.ai_services_endpoint}contentunderstanding/analyzers/{analyzer_id}:analyzeBinary"
+    )
+    trace.request_method = "POST"
+    trace.request_headers = sanitize_headers({"Content-Type": content_type})
+    trace.request_body = {"filename": filename}
+
+    with TraceTimer() as timer:
+        try:
+            _ensure_defaults(client)
+
+            def _run_analysis() -> Any:
+                poller = client.begin_analyze_binary(
+                    analyzer_id=analyzer_id,
+                    binary_input=file_bytes,
+                    content_type=content_type,
+                )
+                return poller.result()
+
+            result = await asyncio.to_thread(_run_analysis)
+            trace.response_status = 200
+            result_dict = _result_to_dict(result)
+            trace.response_body = _summarize_cu_result(result_dict)
         except HttpResponseError as e:
             trace.error = f"HttpResponseError: {e}"
             trace.response_status = e.status_code or 500
@@ -143,20 +231,23 @@ def _ensure_defaults(client: Any) -> None:
     try:
         client.update_defaults(
             model_deployments={
-                "gpt-4.1": settings.cu_completion_deployment,
-                "text-embedding-3-large": settings.cu_embedding_deployment,
+                settings.cu_completion_model: settings.cu_completion_deployment,
+                settings.cu_embedding_model: settings.cu_embedding_deployment,
             }
         )
         _defaults_configured = True
         logger.info(
-            "CU defaults configured: gpt-4.1→%s, text-embedding-3-large→%s",
+            "CU defaults configured: %s→%s, %s→%s",
+            settings.cu_completion_model,
             settings.cu_completion_deployment,
+            settings.cu_embedding_model,
             settings.cu_embedding_deployment,
         )
     except Exception as e:
         logger.warning(
-            "Failed to set CU defaults (gpt-4.1→%s): %s — "
+            "Failed to set CU defaults (%s→%s): %s — "
             "CU custom analyzers may fail if deployment names don't match",
+            settings.cu_completion_model,
             settings.cu_completion_deployment,
             e,
         )
@@ -170,12 +261,16 @@ def _ensure_analyzer(client: Any, analyzer_id: str, fields: list[dict[str, str]]
         logger.debug("Analyzer '%s' already exists", analyzer_id)
         return False
     except Exception:
-        logger.info("Analyzer '%s' not found — creating with completion model gpt-4.1", analyzer_id)
+        logger.info(
+            "Analyzer '%s' not found — creating with completion model %s",
+            analyzer_id,
+            settings.cu_completion_model,
+        )
         analyzer_def: dict[str, Any] = {
             "description": f"Workshop custom analyzer: {analyzer_id}",
             "scenario": "document",
             "baseAnalyzerId": "prebuilt-document",
-            "models": {"completion": "gpt-4.1"},
+            "models": {"completion": settings.cu_completion_model},
         }
         if fields:
             analyzer_def["fieldSchema"] = {
@@ -197,7 +292,7 @@ def _ensure_analyzer(client: Any, analyzer_id: str, fields: list[dict[str, str]]
             logger.error("Failed to create analyzer '%s': %s", analyzer_id, e)
             raise RuntimeError(
                 f"CU analyzer creation failed for '{analyzer_id}': {e}. "
-                f"Check that GPT-4.1 deployment "
+                f"Check that {settings.cu_completion_model} deployment "
                 f"'{settings.cu_completion_deployment}' exists."
             ) from e
 

--- a/src/workshop/services/patient_log_analyzers.py
+++ b/src/workshop/services/patient_log_analyzers.py
@@ -1,0 +1,309 @@
+"""Analyzer definitions for the CU-only patient log demo."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+PATIENT_LOG_CLASSIFIER_ID = "patient_log_classifier"
+PATIENT_LOG_TREATMENT_ID = "patient_log_treatment"
+
+
+def get_patient_log_analyzer_definitions(
+    completion_model: str = "gpt-5.2",
+    embedding_model: str = "text-embedding-3-large",
+) -> dict[str, dict[str, Any]]:
+    """Return Content Understanding analyzer definitions for the patient log demo."""
+    return {
+        PATIENT_LOG_TREATMENT_ID: _treatment_log_analyzer(completion_model, embedding_model),
+        PATIENT_LOG_CLASSIFIER_ID: _classifier_analyzer(completion_model),
+    }
+
+
+def get_patient_log_analyzer_definition(
+    analyzer_id: str,
+    completion_model: str = "gpt-5.2",
+    embedding_model: str = "text-embedding-3-large",
+) -> dict[str, Any]:
+    """Return a copy of a single patient log analyzer definition."""
+    definitions = get_patient_log_analyzer_definitions(completion_model, embedding_model)
+    return deepcopy(definitions[analyzer_id])
+
+
+def _treatment_log_analyzer(completion_model: str, embedding_model: str) -> dict[str, Any]:
+    return {
+        "description": "CU-only analyzer for scanned patient treatment logs and body diagrams.",
+        "baseAnalyzerId": "prebuilt-document",
+        "models": {
+            "completion": completion_model,
+            "embedding": embedding_model,
+        },
+        "config": {
+            "returnDetails": True,
+            "enableFormula": False,
+            "estimateFieldSourceAndConfidence": True,
+            "tableFormat": "html",
+        },
+        "fieldSchema": {
+            "fields": {
+                "document_instance_id": {
+                    "type": "string",
+                    "method": "generate",
+                    "description": (
+                        "Stable label for this treatment log instance, such as page range, "
+                        "copy number, or visible form identifier."
+                    ),
+                },
+                "patient_identifiers_present": {
+                    "type": "string",
+                    "method": "generate",
+                    "description": (
+                        "Describe whether patient identifiers are present without reproducing "
+                        "sensitive values. Use values like present, absent, or unclear."
+                    ),
+                },
+                "provider_or_clinic": {
+                    "type": "string",
+                    "method": "generate",
+                    "description": "Provider, therapist, clinic, or facility name if visible.",
+                },
+                "service_period": {
+                    "type": "string",
+                    "method": "generate",
+                    "description": (
+                        "Service date range, month, or treatment period covered by the log."
+                    ),
+                },
+                "visit_entries": {
+                    "type": "array",
+                    "method": "generate",
+                    "description": (
+                        "Each treatment row or visit entry visible in the log, including date, "
+                        "services selected, provider initials, patient signature, and notes."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "date": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": "Visit date or row date as displayed.",
+                            },
+                            "services_or_modalities": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": (
+                                    "Checked services, modalities, or treatment activities."
+                                ),
+                            },
+                            "initials_or_signature_present": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": "Whether initials or signature evidence is visible.",
+                            },
+                            "row_confidence": {
+                                "type": "string",
+                                "method": "classify",
+                                "enum": ["high", "medium", "low", "unclear"],
+                                "description": "Confidence in the row interpretation.",
+                            },
+                            "ambiguity_note": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": (
+                                    "Any uncertainty about the row, mark, date, or signature."
+                                ),
+                            },
+                        },
+                    },
+                },
+                "body_diagram_findings": {
+                    "type": "array",
+                    "method": "generate",
+                    "description": (
+                        "Visual findings from body diagrams, including circled or drawn regions, "
+                        "body view, laterality, and symptom interpretation if visible."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "source_page_or_segment": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": (
+                                    "Page, segment, or visible area where the mark appears."
+                                ),
+                            },
+                            "body_view": {
+                                "type": "string",
+                                "method": "classify",
+                                "enum": [
+                                    "anterior",
+                                    "posterior",
+                                    "left_lateral",
+                                    "right_lateral",
+                                    "spine",
+                                    "unclear",
+                                ],
+                                "description": "Body view where the finding appears.",
+                            },
+                            "region": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": "Anatomical region or spinal level range marked.",
+                            },
+                            "mark_type": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": (
+                                    "Circle, oval, arrow, handwritten mark, checkbox, or other "
+                                    "visual mark."
+                                ),
+                            },
+                            "symptom_interpretation": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": (
+                                    "Symptom implied by the form legend or nearby text, such as "
+                                    "pain, spasm, edema, ache, burning, or tingling. Say unclear "
+                                    "when not supported."
+                                ),
+                            },
+                            "confidence": {
+                                "type": "string",
+                                "method": "classify",
+                                "enum": ["high", "medium", "low", "unclear"],
+                                "description": "Confidence in the visual interpretation.",
+                            },
+                            "ambiguity_note": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": "Why this visual finding is ambiguous or reliable.",
+                            },
+                        },
+                    },
+                },
+                "spinal_palpation_findings": {
+                    "type": "array",
+                    "method": "generate",
+                    "description": (
+                        "Spinal palpation annotations, including marked levels like C4-C6, arrows, "
+                        "lines, checks, or other visible indicators."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "level_or_range": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": (
+                                    "Spinal level or range associated with the visual mark."
+                                ),
+                            },
+                            "mark_description": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": (
+                                    "Description of the visible mark near the spinal level."
+                                ),
+                            },
+                            "confidence": {
+                                "type": "string",
+                                "method": "classify",
+                                "enum": ["high", "medium", "low", "unclear"],
+                                "description": "Confidence in the level interpretation.",
+                            },
+                        },
+                    },
+                },
+                "missing_or_incomplete_entries": {
+                    "type": "array",
+                    "method": "generate",
+                    "description": (
+                        "Rows or sections that appear incomplete, including missing dates, "
+                        "signatures, service selections, or unclear handwritten entries."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": (
+                                    "Page, segment, row, or section where the gap appears."
+                                ),
+                            },
+                            "issue": {
+                                "type": "string",
+                                "method": "generate",
+                                "description": "Missing or incomplete information observed.",
+                            },
+                            "severity": {
+                                "type": "string",
+                                "method": "classify",
+                                "enum": ["high", "medium", "low"],
+                                "description": "How important the missing information appears.",
+                            },
+                        },
+                    },
+                },
+                "overall_summary": {
+                    "type": "string",
+                    "method": "generate",
+                    "description": (
+                        "Short summary of the treatment log, visible body diagram findings, "
+                        "missing information, and notable uncertainties."
+                    ),
+                },
+                "ambiguities": {
+                    "type": "array",
+                    "method": "generate",
+                    "description": "Key uncertainties that should be reviewed by a human.",
+                    "items": {"type": "string"},
+                },
+            }
+        },
+    }
+
+
+def _classifier_analyzer(completion_model: str) -> dict[str, Any]:
+    return {
+        "description": "Segment and route scanned patient log packets by document type.",
+        "baseAnalyzerId": "prebuilt-document",
+        "models": {"completion": completion_model},
+        "config": {
+            "returnDetails": True,
+            "enableSegment": True,
+            "omitContent": True,
+            "contentCategories": {
+                "patient_treatment_log": {
+                    "description": (
+                        "Treatment log or attendance chart pages with visit rows, service "
+                        "checkboxes, patient/provider signatures, or body diagram sections."
+                    ),
+                    "analyzerId": PATIENT_LOG_TREATMENT_ID,
+                },
+                "palpation_body_diagram": {
+                    "description": (
+                        "Pages or segments dominated by body diagrams, palpation drawings, "
+                        "spinal level markings, or symptom legends."
+                    ),
+                    "analyzerId": PATIENT_LOG_TREATMENT_ID,
+                },
+                "claim_or_cover_sheet": {
+                    "description": (
+                        "Claim packet cover sheets, fax covers, or administrative summary pages."
+                    ),
+                },
+                "invoice_or_billing": {
+                    "description": "Invoices, billing statements, or payment request documents.",
+                },
+                "correspondence": {
+                    "description": "Letters, notes, emails, or other correspondence pages.",
+                },
+                "other": {
+                    "description": "Any content that does not match the patient log categories.",
+                },
+            },
+        },
+    }

--- a/src/workshop/templates/base.html
+++ b/src/workshop/templates/base.html
@@ -61,6 +61,7 @@
 </head>
 <body class="h-full bg-gray-50 text-gray-900">
 
+    {% block nav %}
     <!-- Navigation -->
     <nav class="bg-white border-b border-gray-200 shadow-sm">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -95,6 +96,7 @@
             </div>
         </div>
     </nav>
+    {% endblock %}
 
     <!-- Main content -->
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/src/workshop/templates/patient_log.html
+++ b/src/workshop/templates/patient_log.html
@@ -1,0 +1,331 @@
+{% extends "base.html" %}
+
+{% block title %}Patient Log Analyzer{% endblock %}
+
+{% block nav %}
+<nav class="bg-slate-950 border-b border-slate-800">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex items-center justify-between h-16">
+            <a href="/" class="text-sm text-slate-300 hover:text-white">Azure IDP Workshop</a>
+            <div class="text-white font-semibold">Patient Log Analyzer</div>
+        </div>
+    </div>
+</nav>
+{% endblock %}
+
+{% block content %}
+<div x-data="patientLogDemo()" x-init="loadDefinitions()" x-cloak class="space-y-6">
+    <section class="bg-gradient-to-br from-slate-900 to-blue-950 rounded-2xl shadow-xl p-8 text-white">
+        <div class="max-w-4xl">
+            <div class="text-xs uppercase tracking-wide text-blue-200 font-semibold mb-3">
+                CU-only scenario demo
+            </div>
+            <h1 class="text-3xl md:text-4xl font-bold mb-4">Patient Treatment Log Analyzer</h1>
+            <p class="text-blue-100 leading-relaxed">
+                Segment scanned treatment-log packets and reason over body-diagram markings using
+                Content Understanding only. This demo intentionally does not run Document Intelligence
+                first, so results are semantic findings rather than coordinate-perfect layout evidence.
+            </p>
+        </div>
+    </section>
+
+    <section class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div class="lg:col-span-2 bg-white rounded-xl shadow p-6">
+            <h2 class="text-lg font-semibold mb-3">1. Upload a patient log packet</h2>
+            <p class="text-sm text-gray-600 mb-4">
+                Use an external/manual sample. Real patient or customer documents are not stored,
+                committed, or indexed by this demo.
+            </p>
+            <div class="border-2 border-dashed rounded-xl p-5"
+                 :class="uploadedFile ? 'border-blue-300 bg-blue-50' : 'border-gray-200 bg-gray-50'">
+                <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                    <div>
+                        <div class="font-medium text-gray-900" x-text="uploadedFile ? uploadedFile.name : 'No file selected'"></div>
+                        <p class="text-xs text-gray-500 mt-1">
+                            PDF, images, Office, or HTML. Maximum 10 MB per upload.
+                        </p>
+                        <p x-show="uploadError" class="text-xs text-red-700 mt-2" x-text="uploadError"></p>
+                    </div>
+                    <label class="inline-flex items-center justify-center px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 cursor-pointer">
+                        Choose file
+                        <input type="file" class="sr-only"
+                               accept=".pdf,.jpeg,.jpg,.png,.bmp,.tiff,.tif,.heif,.heic,.docx,.xlsx,.pptx,.html"
+                               @change="handleUpload($event)" />
+                    </label>
+                </div>
+            </div>
+
+            <div class="flex flex-wrap gap-3 mt-5">
+                <input type="password" x-model="adminKey" placeholder="Admin key for analyzer setup"
+                       class="px-3 py-2 border border-gray-300 rounded-lg text-sm min-w-64" />
+                <button @click="ensureAnalyzers()" :disabled="ensuring"
+                    class="px-4 py-2 rounded-lg bg-slate-800 text-white text-sm font-medium hover:bg-slate-900 disabled:opacity-50">
+                    <span x-show="!ensuring">Create/update analyzers</span>
+                    <span x-show="ensuring">Creating analyzers...</span>
+                </button>
+                <button @click="analyze()" :disabled="!canAnalyze || analyzing"
+                    class="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50">
+                    <span x-show="!analyzing">Analyze packet</span>
+                    <span x-show="analyzing">Analyzing...</span>
+                </button>
+                <button @click="downloadResults()" :disabled="!analysisResult"
+                    class="px-4 py-2 rounded-lg bg-white border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 disabled:opacity-50">
+                    Export JSON
+                </button>
+            </div>
+        </div>
+
+        <aside class="bg-amber-50 border border-amber-200 rounded-xl p-6">
+            <h2 class="font-semibold text-amber-900 mb-2">What this proves</h2>
+            <ul class="text-sm text-amber-800 space-y-2 list-disc pl-5">
+                <li>Classifier segmentation can split repeated forms in one packet.</li>
+                <li>CU can reason over scanned body diagrams and handwritten visual marks.</li>
+                <li>Semantic findings can include ambiguity notes for human review.</li>
+                <li>No server-side storage or Search indexing is used for patient-log output.</li>
+            </ul>
+        </aside>
+    </section>
+
+    <section x-show="ensureResult || analysisResult || errorMessage" class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div class="bg-white rounded-xl shadow p-6">
+            <h2 class="text-lg font-semibold mb-4">Analyzer status</h2>
+            <template x-if="ensureResult?.result?.analyzers">
+                <div class="space-y-3">
+                    <template x-for="analyzer in ensureResult.result.analyzers" :key="analyzer.id">
+                        <div class="border rounded-lg p-3 flex items-center justify-between">
+                            <div>
+                                <div class="font-mono text-sm text-slate-800" x-text="analyzer.id"></div>
+                                <div class="text-xs text-gray-500" x-text="analyzer.kind"></div>
+                            </div>
+                            <span class="text-xs px-2 py-1 rounded-full"
+                                  :class="analyzer.status === 'ready' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'"
+                                  x-text="analyzer.status"></span>
+                        </div>
+                    </template>
+                </div>
+            </template>
+            <template x-if="!ensureResult">
+                <p class="text-sm text-gray-500">Create analyzers before running the live demo, or use mocked test responses during development.</p>
+            </template>
+        </div>
+
+        <div x-show="errorMessage" class="bg-red-50 border border-red-200 rounded-xl p-6">
+            <h2 class="font-semibold text-red-800 mb-2">Request failed</h2>
+            <pre class="text-sm text-red-700 whitespace-pre-wrap" x-text="errorMessage"></pre>
+        </div>
+    </section>
+
+    <section x-show="analysisResult" class="bg-white rounded-xl shadow p-6">
+        <div class="flex items-start justify-between gap-4 mb-4">
+            <div>
+                <h2 class="text-lg font-semibold">Patient log findings</h2>
+                <p class="text-sm text-gray-500">
+                    Results are generated by <span class="font-mono" x-text="analysisResult?.result?.analyzer_id"></span>.
+                </p>
+            </div>
+            <span class="text-xs px-2 py-1 bg-blue-100 text-blue-700 rounded-full">CU-only</span>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div>
+                <h3 class="font-semibold text-slate-800 mb-2">Segments and categories</h3>
+                <template x-if="segments().length">
+                    <div class="space-y-2">
+                        <template x-for="(segment, index) in segments()" :key="index">
+                            <div class="border rounded-lg p-3">
+                                <div class="font-medium" x-text="segment.category || segment.type || 'Segment'"></div>
+                                <div class="text-xs text-gray-500" x-text="segment.pageRange || segment.pages || segment.source || ''"></div>
+                            </div>
+                        </template>
+                    </div>
+                </template>
+                <p x-show="!segments().length" class="text-sm text-gray-500">No explicit segment list found in the response.</p>
+            </div>
+
+            <div>
+                <h3 class="font-semibold text-slate-800 mb-2">Body diagram findings</h3>
+                <template x-if="bodyFindings().length">
+                    <div class="space-y-2">
+                        <template x-for="(finding, index) in bodyFindings()" :key="index">
+                            <div class="bg-blue-50 border border-blue-100 rounded-lg p-3">
+                                <div class="font-medium text-blue-900" x-text="display(finding.region || finding.level_or_range) || 'Visual finding'"></div>
+                                <div class="text-sm text-blue-800 mt-1" x-text="display(finding.symptom_interpretation || finding.mark_description || finding.mark_type)"></div>
+                                <div class="text-xs text-blue-600 mt-1" x-text="display(finding.ambiguity_note || finding.confidence)"></div>
+                            </div>
+                        </template>
+                    </div>
+                </template>
+                <p x-show="!bodyFindings().length" class="text-sm text-gray-500">No body-diagram findings found in the response.</p>
+            </div>
+        </div>
+
+        <details class="mt-6">
+            <summary class="cursor-pointer text-sm font-medium text-blue-700">View raw analysis JSON</summary>
+            <pre class="mt-2 bg-gray-900 text-green-300 p-4 rounded text-xs overflow-auto max-h-96"><code x-text="JSON.stringify(analysisResult, null, 2)"></code></pre>
+        </details>
+    </section>
+
+    <section class="bg-white rounded-xl shadow p-6">
+        <div class="flex items-start justify-between gap-4">
+            <div>
+                <h2 class="text-lg font-semibold">Portal demo definitions</h2>
+                <p class="text-sm text-gray-500">
+                    Use these definitions as the source of truth when recreating the same classifier/segmenter and treatment analyzer in Content Understanding Studio.
+                </p>
+            </div>
+            <button @click="copyDefinitions()" class="px-3 py-1.5 rounded border text-sm hover:bg-gray-50">
+                Copy JSON
+            </button>
+        </div>
+        <pre class="mt-4 bg-gray-900 text-green-300 p-4 rounded text-xs overflow-auto max-h-96"><code x-text="JSON.stringify(definitions, null, 2)"></code></pre>
+    </section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function patientLogDemo() {
+    return {
+        uploadedFile: null,
+        uploadError: '',
+        ensuring: false,
+        analyzing: false,
+        ensureResult: null,
+        analysisResult: null,
+        definitions: null,
+        errorMessage: '',
+        adminKey: '',
+        uploadLimitBytes: 10 * 1024 * 1024,
+        acceptedExtensions: ['.pdf', '.jpeg', '.jpg', '.png', '.bmp', '.tiff', '.tif', '.heif', '.heic', '.docx', '.xlsx', '.pptx', '.html'],
+        get canAnalyze() { return !!this.uploadedFile && !this.uploadError; },
+        async loadDefinitions() {
+            const resp = await fetch('/api/patient-logs/analyzer-definitions');
+            if (resp.ok) this.definitions = await resp.json();
+        },
+        handleUpload(event) {
+            this.uploadError = '';
+            this.analysisResult = null;
+            const file = event.target.files?.[0];
+            if (!file) {
+                this.uploadedFile = null;
+                return;
+            }
+            const ext = file.name.includes('.') ? '.' + file.name.split('.').pop().toLowerCase() : '';
+            if (!this.acceptedExtensions.includes(ext)) {
+                this.uploadedFile = null;
+                this.uploadError = 'Unsupported file type. Use PDF, image, Office, or HTML documents.';
+                return;
+            }
+            if (file.size > this.uploadLimitBytes) {
+                this.uploadedFile = null;
+                this.uploadError = 'File exceeds the 10 MB upload limit.';
+                return;
+            }
+            this.uploadedFile = file;
+        },
+        async ensureAnalyzers() {
+            this.ensuring = true;
+            this.errorMessage = '';
+            try {
+                const headers = this.adminKey ? { 'X-Admin-Key': this.adminKey } : {};
+                const resp = await fetch('/api/patient-logs/ensure-analyzers', { method: 'POST', headers });
+                if (!resp.ok) throw new Error(await resp.text() || 'HTTP ' + resp.status);
+                this.ensureResult = await resp.json();
+            } catch (e) {
+                this.errorMessage = e instanceof Error ? e.message : String(e);
+            } finally {
+                this.ensuring = false;
+            }
+        },
+        async analyze() {
+            if (!this.canAnalyze) return;
+            this.analyzing = true;
+            this.errorMessage = '';
+            this.analysisResult = null;
+            try {
+                const form = new FormData();
+                form.append('file', this.uploadedFile);
+                const resp = await fetch('/api/patient-logs/analyze', { method: 'POST', body: form });
+                if (!resp.ok) throw new Error(await resp.text() || 'HTTP ' + resp.status);
+                this.analysisResult = await resp.json();
+            } catch (e) {
+                this.errorMessage = e instanceof Error ? e.message : String(e);
+            } finally {
+                this.analyzing = false;
+            }
+        },
+        segments() {
+            const analysis = this.analysisResult?.result?.analysis || {};
+            return analysis.segments || analysis.result?.segments || analysis.contents || [];
+        },
+        bodyFindings() {
+            const analysis = this.analysisResult?.result?.analysis;
+            const contentFields = this.contentItems()
+                .map((content) => content?.fields)
+                .filter(Boolean);
+            const fieldsList = contentFields.length ? contentFields : this.findAllFields(analysis);
+            return fieldsList.flatMap((fields) => {
+                const body = fields?.body_diagram_findings || fields?.BodyDiagramFindings;
+                const spinal = fields?.spinal_palpation_findings || fields?.SpinalPalpationFindings;
+                return [...this.fieldArray(body), ...this.fieldArray(spinal)];
+            });
+        },
+        contentItems() {
+            const analysis = this.analysisResult?.result?.analysis || {};
+            return analysis.contents || analysis.result?.contents || [];
+        },
+        findFields(value) {
+            if (!value || typeof value !== 'object') return null;
+            if (value.fields) return value.fields;
+            for (const nested of Object.values(value)) {
+                const found = this.findFields(nested);
+                if (found) return found;
+            }
+            return null;
+        },
+        findAllFields(value, found = []) {
+            if (!value || typeof value !== 'object') return found;
+            if (value.fields) found.push(value.fields);
+            for (const nested of Object.values(value)) {
+                this.findAllFields(nested, found);
+            }
+            return found;
+        },
+        fieldArray(field) {
+            const value = field?.valueArray || field?.value || field;
+            if (!Array.isArray(value)) return [];
+            return value.map((item) => item?.valueObject || item?.value || item);
+        },
+        display(value) {
+            if (value == null) return '';
+            if (typeof value !== 'object') return String(value);
+            if (value.valueString != null) return String(value.valueString);
+            if (value.content != null) return String(value.content);
+            if (value.value != null) return this.display(value.value);
+            if (value.valueNumber != null) return String(value.valueNumber);
+            if (value.valueDate != null) return String(value.valueDate);
+            if (value.valueTime != null) return String(value.valueTime);
+            if (value.valueBoolean != null) return String(value.valueBoolean);
+            if (value.valueObject) return this.display(value.valueObject);
+            return JSON.stringify(value);
+        },
+        downloadResults() {
+            if (!this.analysisResult) return;
+            this.downloadJson(this.analysisResult, 'patient-log-analysis.json');
+        },
+        copyDefinitions() {
+            navigator.clipboard?.writeText(JSON.stringify(this.definitions, null, 2));
+        },
+        downloadJson(data, filename) {
+            const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            a.click();
+            URL.revokeObjectURL(url);
+        },
+    };
+}
+</script>
+{% endblock %}

--- a/tests/e2e/patient-log.spec.ts
+++ b/tests/e2e/patient-log.spec.ts
@@ -1,0 +1,207 @@
+import { Route } from "@playwright/test";
+import path from "path";
+import { test, expect } from "./helpers";
+
+const uploadFixturePath = path.join(process.cwd(), "samples", "invoice.pdf");
+
+function mockJsonRoute(route: Route, body: object, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+function mockTextRoute(route: Route, body: string, status = 500) {
+  return route.fulfill({ status, contentType: "text/plain", body });
+}
+
+const definitionsResult = {
+  result: {
+    classifier_analyzer_id: "patient_log_classifier",
+    treatment_analyzer_id: "patient_log_treatment",
+    definitions: {
+      patient_log_classifier: {
+        baseAnalyzerId: "prebuilt-document",
+        config: {
+          enableSegment: true,
+          contentCategories: {
+            patient_treatment_log: { analyzerId: "patient_log_treatment" },
+          },
+        },
+      },
+      patient_log_treatment: {
+        baseAnalyzerId: "prebuilt-document",
+        fieldSchema: {
+          fields: {
+            body_diagram_findings: { type: "array" },
+            spinal_palpation_findings: { type: "array" },
+          },
+        },
+      },
+    },
+  },
+};
+
+const ensureResult = {
+  result: {
+    ready: true,
+    analyzers: [
+      {
+        id: "patient_log_treatment",
+        kind: "treatment-log extractor",
+        status: "ready",
+      },
+      {
+        id: "patient_log_classifier",
+        kind: "classifier/segmenter-router",
+        status: "ready",
+      },
+    ],
+  },
+  trace: {},
+};
+
+const analysisResult = {
+  result: {
+    filename: "patient-log.pdf",
+    analyzer_id: "patient_log_classifier",
+    analysis: {
+      segments: [
+        {
+          category: "patient_treatment_log",
+          pageRange: "pages 1-2",
+        },
+      ],
+      fields: {
+        body_diagram_findings: {
+          value: [
+            {
+              region: { valueString: "posterior upper back / scapular area" },
+              mark_type: { valueString: "circled region" },
+              symptom_interpretation: {
+                valueString: "symptom type is unclear from the mark alone",
+              },
+              confidence: { valueString: "medium" },
+            },
+          ],
+        },
+        spinal_palpation_findings: {
+          value: [
+            {
+              level_or_range: { valueString: "C4-C6" },
+              mark_description: { valueString: "arrow near cervical spine levels" },
+              confidence: { valueString: "medium" },
+            },
+          ],
+        },
+      },
+      contents: [
+        {
+          fields: {
+            body_diagram_findings: {
+              value: [
+                {
+                  region: { valueString: "posterior upper back / scapular area" },
+                  mark_type: { valueString: "circled region" },
+                  symptom_interpretation: {
+                    valueString: "symptom type is unclear from the mark alone",
+                  },
+                  confidence: { valueString: "medium" },
+                },
+              ],
+            },
+          },
+        },
+        {
+          fields: {
+            body_diagram_findings: {
+              value: [
+                {
+                  region: { valueString: "left lower leg / knee region" },
+                  mark_type: { valueString: "circled region" },
+                  symptom_interpretation: { valueString: "pain mark is possible but unclear" },
+                  confidence: { valueString: "medium" },
+                },
+              ],
+            },
+            spinal_palpation_findings: {
+              value: [
+                {
+                  level_or_range: { valueString: "C4-C6" },
+                  mark_description: { valueString: "arrow near cervical spine levels" },
+                  confidence: { valueString: "medium" },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  },
+  trace: { response_status: 200 },
+};
+
+test.describe("Patient Log Analyzer", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/patient-logs/analyzer-definitions", (route) =>
+      mockJsonRoute(route, definitionsResult)
+    );
+  });
+
+  test("loads as a standalone direct page", async ({ page, consoleErrors }) => {
+    await page.goto("/patient-log");
+
+    await expect(
+      page.getByRole("heading", { name: "Patient Treatment Log Analyzer" })
+    ).toBeVisible();
+    await expect(page.getByText("CU-only scenario demo")).toBeVisible();
+    await expect(page.getByRole("link", { name: /Module 1/i })).not.toBeVisible();
+    await expect(page.getByText("patient_log_classifier")).toBeVisible();
+  });
+
+  test("creates analyzers and renders analysis findings", async ({ page, consoleErrors }) => {
+    await page.route("**/api/patient-logs/ensure-analyzers", (route) =>
+      mockJsonRoute(route, ensureResult)
+    );
+    await page.route("**/api/patient-logs/analyze", (route) =>
+      mockJsonRoute(route, analysisResult)
+    );
+
+    await page.goto("/patient-log");
+    await page.getByLabel("Choose file").setInputFiles(uploadFixturePath);
+    await page.getByPlaceholder("Admin key for analyzer setup").fill("test-admin-key");
+    await page.getByRole("button", { name: /Create\/update analyzers/i }).click();
+    await expect(page.getByText("patient_log_treatment").first()).toBeVisible();
+
+    const analyzeRequestPromise = page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/api/patient-logs/analyze") && request.method() === "POST"
+    );
+    await page.getByRole("button", { name: /Analyze packet/i }).click();
+    const analyzeRequest = await analyzeRequestPromise;
+    expect(analyzeRequest.headers()["content-type"]).toContain("multipart/form-data");
+
+    const findings = page.locator("section").filter({
+      has: page.getByRole("heading", { name: "Patient log findings" }),
+    });
+    await expect(findings.getByText("patient_treatment_log", { exact: true }).first()).toBeVisible();
+    await expect(findings.getByText("posterior upper back / scapular area").first()).toBeVisible();
+    await expect(findings.getByText("left lower leg / knee region").first()).toBeVisible();
+    await expect(findings.getByText("C4-C6").first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Export JSON" })).toBeEnabled();
+  });
+
+  test("shows plain text API errors without crashing", async ({ page, consoleErrors }) => {
+    await page.route("**/api/patient-logs/ensure-analyzers", (route) =>
+      mockTextRoute(route, "Service Unavailable", 503)
+    );
+
+    await page.goto("/patient-log");
+    await page.getByRole("button", { name: /Create\/update analyzers/i }).click();
+
+    await expect(page.getByText("Request failed")).toBeVisible();
+    await expect(page.getByText("Service Unavailable")).toBeVisible();
+    await expect(page.getByText("Unexpected token")).not.toBeVisible();
+  });
+});

--- a/tests/test_cu_router.py
+++ b/tests/test_cu_router.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+from workshop.services.patient_log_analyzers import PATIENT_LOG_CLASSIFIER_ID
+
 
 def test_cu_layout_requires_file_or_sample(client):  # type: ignore[no-untyped-def]
     resp = client.post("/api/cu/layout")
@@ -86,3 +88,22 @@ def test_cu_custom_multipart_rejects_invalid_fields(client):  # type: ignore[no-
     )
     assert resp.status_code == 400
     assert "valid JSON" in resp.json()["detail"]
+
+
+def test_cu_custom_rejects_reserved_patient_log_analyzer_json(client):  # type: ignore[no-untyped-def]
+    resp = client.post(
+        "/api/cu/custom",
+        json={"sample": "contract.pdf", "analyzer_id": PATIENT_LOG_CLASSIFIER_ID},
+    )
+    assert resp.status_code == 403
+    assert "reserved" in resp.json()["detail"]
+
+
+def test_cu_custom_rejects_reserved_patient_log_analyzer_upload(client):  # type: ignore[no-untyped-def]
+    resp = client.post(
+        "/api/cu/custom",
+        data={"analyzer_id": PATIENT_LOG_CLASSIFIER_ID},
+        files={"file": ("upload.pdf", b"%PDF-1.4\n", "application/pdf")},
+    )
+    assert resp.status_code == 403
+    assert "reserved" in resp.json()["detail"]

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -33,3 +33,9 @@ def test_guide_page(client):  # type: ignore[no-untyped-def]
     resp = client.get("/guide")
     assert resp.status_code == 200
     assert "Decision" in resp.text
+
+
+def test_patient_log_page(client):  # type: ignore[no-untyped-def]
+    resp = client.get("/patient-log")
+    assert resp.status_code == 200
+    assert "Patient Treatment Log Analyzer" in resp.text

--- a/tests/test_patient_logs.py
+++ b/tests/test_patient_logs.py
@@ -1,0 +1,114 @@
+"""Patient log analyzer demo tests."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from workshop.services.patient_log_analyzers import (
+    PATIENT_LOG_CLASSIFIER_ID,
+    PATIENT_LOG_TREATMENT_ID,
+    get_patient_log_analyzer_definitions,
+)
+
+
+def test_patient_log_analyzer_definitions_include_segmenter_and_extractor() -> None:
+    definitions = get_patient_log_analyzer_definitions()
+
+    classifier = definitions[PATIENT_LOG_CLASSIFIER_ID]
+    treatment = definitions[PATIENT_LOG_TREATMENT_ID]
+
+    assert classifier["config"]["enableSegment"] is True
+    assert (
+        classifier["config"]["contentCategories"]["patient_treatment_log"]["analyzerId"]
+        == PATIENT_LOG_TREATMENT_ID
+    )
+    assert "body_diagram_findings" in treatment["fieldSchema"]["fields"]
+    assert "spinal_palpation_findings" in treatment["fieldSchema"]["fields"]
+    assert treatment["baseAnalyzerId"] == "prebuilt-document"
+
+
+def test_patient_log_page_renders(client):  # type: ignore[no-untyped-def]
+    resp = client.get("/patient-log")
+    assert resp.status_code == 200
+    assert "Patient Treatment Log Analyzer" in resp.text
+    assert "Module 1" not in resp.text
+
+
+def test_analyzer_definitions_endpoint(client):  # type: ignore[no-untyped-def]
+    resp = client.get("/api/patient-logs/analyzer-definitions")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["classifier_analyzer_id"] == PATIENT_LOG_CLASSIFIER_ID
+    assert PATIENT_LOG_TREATMENT_ID in body["result"]["definitions"]
+
+
+def test_ensure_patient_log_analyzers(client):  # type: ignore[no-untyped-def]
+    with (
+        patch("workshop.routers.patient_logs.settings.admin_api_key", "test-admin-key"),
+        patch(
+            "workshop.routers.patient_logs.cu_service.create_or_replace_analyzer",
+            AsyncMock(return_value={"result": {}, "trace": {"response": {"status": 200}}}),
+        ) as mock_create,
+    ):
+        resp = client.post(
+            "/api/patient-logs/ensure-analyzers",
+            headers={"X-Admin-Key": "test-admin-key"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["ready"] is True
+    assert mock_create.call_count == 2
+    assert mock_create.call_args_list[0].args[0] == PATIENT_LOG_TREATMENT_ID
+    assert mock_create.call_args_list[1].args[0] == PATIENT_LOG_CLASSIFIER_ID
+
+
+def test_ensure_patient_log_analyzers_requires_admin_key(client):  # type: ignore[no-untyped-def]
+    with patch("workshop.routers.patient_logs.settings.admin_api_key", "test-admin-key"):
+        resp = client.post("/api/patient-logs/ensure-analyzers")
+
+    assert resp.status_code == 403
+    assert "admin" in resp.json()["detail"].lower()
+
+
+def test_ensure_patient_log_analyzers_disabled_without_admin_key(client):  # type: ignore[no-untyped-def]
+    with patch("workshop.routers.patient_logs.settings.admin_api_key", ""):
+        resp = client.post("/api/patient-logs/ensure-analyzers")
+
+    assert resp.status_code == 403
+    assert "disabled" in resp.json()["detail"].lower()
+
+
+def test_analyze_patient_log_upload(client):  # type: ignore[no-untyped-def]
+    with patch(
+        "workshop.routers.patient_logs.cu_service.analyze_binary_with_analyzer",
+        AsyncMock(
+            return_value={
+                "result": {
+                    "fields": {
+                        "overall_summary": {"value": "Treatment log with body diagram marks"}
+                    }
+                },
+                "trace": {"response": {"status": 200}},
+            }
+        ),
+    ) as mock_analyze:
+        resp = client.post(
+            "/api/patient-logs/analyze",
+            files={"file": ("patient-log.pdf", b"%PDF-1.4\n", "application/pdf")},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["filename"] == "patient-log.pdf"
+    assert body["result"]["analyzer_id"] == PATIENT_LOG_CLASSIFIER_ID
+    assert mock_analyze.call_args.args[0] == PATIENT_LOG_CLASSIFIER_ID
+
+
+def test_analyze_patient_log_rejects_unsupported_upload(client):  # type: ignore[no-untyped-def]
+    resp = client.post(
+        "/api/patient-logs/analyze",
+        files={"file": ("patient-log.txt", b"not supported", "text/plain")},
+    )
+    assert resp.status_code == 400
+    assert "does not support" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

Add a direct CU-only patient log analyzer scenario at `/patient-log`.

### Changes

- Add patient-log analyzer definitions for a classifier/segmenter and routed treatment-log extractor.
- Add patient-log API endpoints to return analyzer definitions, create/update analyzers, and analyze uploaded packets.
- Add a standalone direct-URL patient-log page with upload, analyzer setup, analysis rendering, raw trace viewing, and browser-side JSON export.
- Default CU completion model/deployment to `gpt-5.2` while keeping `gpt-4.1` deployed as a fallback.
- Add optional Foundry project IaC under the existing AI Services resource for portal/model UX.
- Update deployment workflows, config, and docs for `gpt-5.2`, the portal region caveat, and the direct API fallback path.
- Add backend and Playwright coverage for the new scenario.

### Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `az bicep build --file infra/main.bicep --stdout`
- `uv run pytest -v` (110 passed)
- `npx playwright test --grep-invert Smoke --project="Desktop Edge"` (37 passed)
- `BASE_URL=<deployed-app> npx playwright test --grep Smoke --project="Desktop Edge"` (10 passed)
