### PR TITLE
fix: Serialize Cognitive Services model deployments to prevent RequestConflict

### DIFF
--- a/infra/modules/ai-services.bicep
+++ b/infra/modules/ai-services.bicep
@@ -71,10 +71,13 @@ resource completion 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01
   }
 }
 
-// GPT-4.1 fallback while validating newer CU completion models
+// GPT-4.1 fallback while validating newer CU completion models.
+// Serialized after the primary completion deployment: Cognitive Services
+// rejects concurrent deployment operations on the same account (RequestConflict).
 resource gpt41Fallback 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = if (deployGpt41Fallback && cuCompletionDeploymentName != 'gpt-4.1') {
   parent: aiServices
   name: 'gpt-4.1'
+  dependsOn: [completion]
   sku: {
     name: 'GlobalStandard'
     capacity: 10
@@ -88,11 +91,12 @@ resource gpt41Fallback 'Microsoft.CognitiveServices/accounts/deployments@2024-10
   }
 }
 
-// Text embedding deployment (required for CU)
+// Text embedding deployment (required for CU). Serialized after the prior
+// model deployments so all account/deployments operations run sequentially.
 resource embedding 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
   parent: aiServices
   name: cuEmbeddingDeploymentName
-  dependsOn: [completion]
+  dependsOn: [completion, gpt41Fallback]
   sku: {
     name: 'Standard'
     capacity: 10


### PR DESCRIPTION
## Summary

Fixes the production deploy failure introduced by concurrent Cognitive Services model deployments. The `Deploy Production` workflow failed at the **Ensure infrastructure** step with an Azure `RequestConflict`, which blocked every subsequent step (build, scan, push, deploy, smoke test) -- so the newly scanned image never shipped.

## Root Cause

`infra/modules/ai-services.bicep` declared three `Microsoft.CognitiveServices/accounts/deployments` resources. The primary completion model (`gpt-5.2`) and the `gpt-4.1` fallback had **no ordering between them**, so ARM issued both PUTs in parallel against the same account. Azure does not allow concurrent deployment operations on a single Cognitive Services account:

```
RequestConflict: Another operation is being performed on the parent resource
'.../accounts/idp-workshop-ai'. Please try again later.
```

Investigation confirmed the account and all five model deployments are currently `Succeeded` (the resources converged across retries), and production is healthy (`/api/health` returns `200`). The failure was purely the deployment race, not a broken resource.

## Changes

- `infra/modules/ai-services.bicep`: chain the model deployments so they apply sequentially -- `completion` -> `gpt-4.1` fallback -> `text-embedding-3-large`
- The embedding deployment now depends on both prior deployments, so serialization holds even when the fallback is skipped

## Testing

- `az bicep build infra/modules/ai-services.bicep` -- compiles clean
- Verified live Azure state: account `Succeeded`, all model deployments `Succeeded`, prod `/api/health` returns `200 {"status":"ok","environment":"prod"}`
- After merge, `Deploy Production` should pass infra (idempotent), then build/scan/push the new image and run smoke tests
