### PR TITLE
ci: Fix Dependabot auto-merge (drop impossible self-approve step)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,14 +18,11 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Auto-approve minor and patch updates
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge (rebase)
+      # Note: we intentionally do NOT self-approve here. The default GITHUB_TOKEN
+      # is blocked from approving PRs ("GitHub Actions is not permitted to approve
+      # pull requests"), and `main` does not require reviews. Auto-merge below gates
+      # on the required CI status checks configured in branch protection.
+      - name: Enable auto-merge (rebase) for non-major updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --rebase "$PR_URL"
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,9 +156,10 @@ For architectural details, deployment patterns, CI/CD pipelines, and troubleshoo
 ## Security Patch Workflow
 
 1. Keep dependencies current via Dependabot PRs (pip/npm/actions/docker).
-2. Fast-track fixes for `CRITICAL/HIGH` vulnerabilities with available patches.
-3. If a finding is not yet fixable upstream, track it explicitly and recheck on each dependency/base-image bump.
-4. Do not bypass Trivy gates silently; if an emergency exception is needed, document the reason and expiry in the PR.
+2. Non-major Dependabot updates are merged automatically: branch protection on `main` requires the CI checks (Lint & Test, Docker Build & Scan, E2E Structural Tests), and the `Dependabot Auto-Merge` workflow enables GitHub auto-merge so the PR lands once those checks pass. Major (`semver-major`) bumps are intentionally left for manual review.
+3. Fast-track fixes for `CRITICAL/HIGH` vulnerabilities with available patches.
+4. If a finding is not yet fixable upstream, track it explicitly and recheck on each dependency/base-image bump.
+5. Do not bypass Trivy gates silently; if an emergency exception is needed, document the reason and expiry in the PR.
 
 ## Health Checks
 


### PR DESCRIPTION
## What

Fixes the broken **Dependabot Auto-Merge** workflow and documents the auto-merge gating model.

## Why

The auto-merge workflow was failing on every non-major Dependabot PR (e.g. #70, #71) at the `Auto-approve` step:

`failed to create review: GraphQL: GitHub Actions is not permitted to approve pull requests. (addPullRequestReview)`

The default `GITHUB_TOKEN` is blocked by GitHub from approving pull requests, so the self-approve step always exited 1 and prevented the subsequent `Enable auto-merge` step from ever running. `#72` only "passed" because its major-version bump skipped both steps via the `semver-major` guard.

`main` does not require PR reviews, so the self-approval was unnecessary in the first place.

## Changes

- **`.github/workflows/dependabot-auto-merge.yml`** — remove the impossible self-approve step; keep enabling GitHub native auto-merge (rebase) for non-major updates. Major bumps remain manual.
- **`CONTRIBUTING.md`** — document that non-major Dependabot PRs auto-merge once the required CI checks pass, and that majors are reviewed manually.

## How auto-merge now works

1. Dependabot opens a PR → this workflow enables GitHub auto-merge (rebase).
2. Branch protection on `main` requires the CI checks (Lint & Test, Docker Build & Scan, E2E Structural Tests).
3. When those checks pass, GitHub.com merges the PR automatically and deletes the branch.

> Branch protection requiring those CI contexts is being configured on `main` alongside this PR so auto-merge has a gate to wait on and bad updates cannot merge.

## Testing

- YAML reviewed; workflow logic unchanged except removal of the failing step.
- Existing green Dependabot PRs (#70, #71, #72) were merged manually as part of clearing the backlog.
