### PR TITLE
fix(infra): Serialize FIC deploys to avoid ARM concurrency error

### DIFF
--- a/infra/modules/deploy-identity.bicep
+++ b/infra/modules/deploy-identity.bicep
@@ -56,6 +56,7 @@ resource ficMain 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIden
 resource ficProduction 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = {
   parent: deployIdentity
   name: 'github-production'
+  dependsOn: [ficMain]
   properties: {
     issuer: 'https://token.actions.githubusercontent.com'
     subject: '${subjectPrefix}:environment:production'


### PR DESCRIPTION
## Problem

The deploy from #87 failed with:
```
ConcurrentFederatedIdentityCredentialsWritesForSingleManagedIdentity
```

Azure doesn't support concurrent writes of multiple federated identity credentials on the same managed identity.

## Fix

Add `dependsOn: [ficMain]` to the `ficProduction` resource so they deploy sequentially instead of in parallel.

## Testing

- `az bicep build` compiles cleanly
- Single-line change with no functional impact beyond ordering